### PR TITLE
feat(notion url parsing + docs): notion Url parsing + docs

### DIFF
--- a/__tests__/__fakes__/fakeDestination.repository.ts
+++ b/__tests__/__fakes__/fakeDestination.repository.ts
@@ -9,6 +9,10 @@ import { FakePage } from './fakePage';
 export class FakeDestinationRepository<T extends Page>
   implements DestinationRepository<T>
 {
+  getPageIdFromPageUrl({ pageUrl }: { pageUrl: string }): string {
+    return pageUrl.split('/').pop() ?? '';
+  }
+
   // Simulate creating a new page
   // eslint-disable-next-line @typescript-eslint/require-await
   async createPage({

--- a/docs/docs/getting-started/1-your-first-synchronization.md
+++ b/docs/docs/getting-started/1-your-first-synchronization.md
@@ -44,6 +44,10 @@ Launch the following command:
 - `--destination` : The Notion page URL where you want to synchronize your markdown files.
 - `--notion-api-token` : Your Notion secret token.
 
+:::warning
+Please note that you can only synchronize markdown files to **Notion Pages**. Notion Databases are not supported for now.
+:::
+
 # Going further
 
 Mk Notes allows you to customize the created Notion pages directly from your markdown files using `frontmatter`

--- a/src/domains/features/synchronizeMarkdownToNotion.test.ts
+++ b/src/domains/features/synchronizeMarkdownToNotion.test.ts
@@ -30,22 +30,6 @@ describe('SynchronizeMarkdownToNotion', () => {
     });
   });
 
-  describe('getPageIdFromPageUrl', () => {
-    it("should correctly extract the page ID from a valid Notion URL", () => {
-      const pageUrl =
-        'https://www.notion.so/workspace/Test-Page-12345678901234567890123456789012';
-      const result = (synchronizer as any).getPageIdFromPageUrl({ pageUrl });
-      expect(result).toBe('12345678901234567890123456789012');
-    });
-
-    it('should throw an error for an invalid Notion URL', () => {
-      const pageUrl = 'https://www.notion.so/workspace/invalid-url';
-      expect(() =>
-        (synchronizer as any).getPageIdFromPageUrl({ pageUrl })
-      ).toThrow('Invalid Notion URL');
-    });
-  });
-
   describe('execute', () => {
     const validNotionUrl =
       'https://www.notion.so/workspace/Test-Page-12345678901234567890123456789012';
@@ -77,7 +61,7 @@ describe('SynchronizeMarkdownToNotion', () => {
       expect(
         destinationRepository.destinationIsAccessible
       ).toHaveBeenCalledWith({
-        parentPageId: '12345678901234567890123456789012',
+        parentPageId: 'Test-Page-12345678901234567890123456789012',
       });
     });
 
@@ -120,7 +104,7 @@ describe('SynchronizeMarkdownToNotion', () => {
       expect(elementConverter.convertToElement).toHaveBeenCalled();
       expect(destinationRepository.createPage).toHaveBeenCalledWith({
         pageElement: expect.any(PageElement),
-        parentPageId: '12345678901234567890123456789012',
+        parentPageId: 'Test-Page-12345678901234567890123456789012',
       });
     });
 

--- a/src/domains/features/synchronizeMarkdownToNotion.ts
+++ b/src/domains/features/synchronizeMarkdownToNotion.ts
@@ -35,22 +35,6 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
     this.logger = params.logger;
   }
 
-  private getPageIdFromPageUrl({ pageUrl }: { pageUrl: string }): string {
-    const urlObj = new URL(pageUrl);
-
-    const pathSegments = urlObj.pathname.split('-');
-    const lastSegment = pathSegments[pathSegments.length - 1];
-
-    if (!lastSegment) {
-      throw new Error('Invalid Notion URL');
-    }
-
-    if (lastSegment.length !== 32) {
-      throw new Error('Invalid Notion URL');
-    }
-
-    return lastSegment;
-  }
   async execute(
     args: T & {
       notionParentPageUrl: string;
@@ -58,7 +42,7 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
   ): Promise<void> {
     const { notionParentPageUrl, ...others } = args;
 
-    const notionPageId = this.getPageIdFromPageUrl({
+    const notionPageId = this.destinationRepository.getPageIdFromPageUrl({
       pageUrl: notionParentPageUrl,
     });
 

--- a/src/domains/synchronization/destination.repository.ts
+++ b/src/domains/synchronization/destination.repository.ts
@@ -26,4 +26,5 @@ export interface DestinationRepository<T extends Page> {
   }: {
     parentPageId: string;
   }) => Promise<boolean>;
+  getPageIdFromPageUrl: ({ pageUrl }: { pageUrl: string }) => string;
 }

--- a/src/infrastructure/notion/notion.destination.test.ts
+++ b/src/infrastructure/notion/notion.destination.test.ts
@@ -9,7 +9,7 @@ import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 jest.mock('@notionhq/client');
 
-describe.skip('NotionDestinationRepository', () => {
+describe('NotionDestinationRepository', () => {
   let repository: NotionDestinationRepository;
   let mockClient: jest.Mocked<Client>;
   let mockNotionConverter: jest.Mocked<NotionConverterRepository>;
@@ -41,7 +41,7 @@ describe.skip('NotionDestinationRepository', () => {
     });
   });
 
-  describe('destinationIsAccessible', () => {
+  describe.skip('destinationIsAccessible', () => {
     it('should return true when page is accessible', async () => {
       jest.spyOn(mockClient.pages,'retrieve').mockResolvedValue({ id: 'page-id', object: 'page' });
 
@@ -66,7 +66,7 @@ describe.skip('NotionDestinationRepository', () => {
     });
   });
 
-  describe('getPageById', () => {
+  describe.skip('getPageById', () => {
     it('should retrieve page with blocks', async () => {
       const mockPage = {
         id: 'page-id',
@@ -102,7 +102,7 @@ describe.skip('NotionDestinationRepository', () => {
     });
   });
 
-  describe('createPage', () => {
+  describe.skip('createPage', () => {
     it('should create page with converted content', async () => {
       const pageElement = new PageElement({
         title: 'Test Page',
@@ -192,7 +192,7 @@ describe.skip('NotionDestinationRepository', () => {
   //   });
   // });
 
-  describe('search', () => {
+  describe.skip('search', () => {
     it('should perform search with filter', async () => {
       const mockSearchResults = {
         results: [{ id: 'page-1' }, { id: 'page-2' }],
@@ -211,7 +211,7 @@ describe.skip('NotionDestinationRepository', () => {
     });
   });
 
-  describe('getBlocksFromPage', () => {
+  describe.skip('getBlocksFromPage', () => {
     it('should retrieve blocks from page', async () => {
       const mockBlocks = {
         results: [{ id: 'block-1' }, { id: 'block-2' }],
@@ -248,5 +248,51 @@ describe.skip('NotionDestinationRepository', () => {
   //     });
   //   });
   // });
+
+  describe('getPageIdFromPageUrl', () => {
+    it('should extract the page ID from a standard Notion URL', () => {
+      const pageUrl = 'https://www.notion.so/workspace/Test-Page-12345678901234567890123456789012';
+      const result = repository.getPageIdFromPageUrl({ pageUrl });
+      expect(result).toBe('12345678901234567890123456789012');
+    });
+
+    it('should extract the page ID from a URL with multiple hyphens', () => {
+      const pageUrl = 'https://www.notion.so/workspace/My-Test-Page-With-Many-Hyphens-12345678901234567890123456789012';
+      const result = repository.getPageIdFromPageUrl({ pageUrl });
+      expect(result).toBe('12345678901234567890123456789012');
+    });
+
+    it('should extract the page ID from a URL without a workspace name', () => {
+      const pageUrl = 'https://www.notion.so/Test-Page-12345678901234567890123456789012';
+      const result = repository.getPageIdFromPageUrl({ pageUrl });
+      expect(result).toBe('12345678901234567890123456789012');
+    });
+
+    it('should throw an error for a URL without a page ID', () => {
+      const pageUrl = 'https://www.notion.so/workspace/Test-Page';
+      expect(() => repository.getPageIdFromPageUrl({ pageUrl })).toThrow('Invalid Notion URL');
+    });
+
+    it('should throw an error for a URL with an invalid page ID length', () => {
+      const pageUrl = 'https://www.notion.so/workspace/Test-Page-123456';
+      expect(() => repository.getPageIdFromPageUrl({ pageUrl })).toThrow('Invalid Notion URL');
+    });
+
+    it('should throw an error for a non-Notion URL', () => {
+      const pageUrl = 'https://example.com/some-page';
+      expect(() => repository.getPageIdFromPageUrl({ pageUrl })).toThrow('Invalid Notion URL');
+    });
+
+    it('should throw an error when the URL is a Notion Database', () => {
+      const pageUrl = 'https://www.notion.so/16d4754ea1e980d1a2fdc2ab5fa4dfaf?v=7d43042815524daa9c5c3a7a4f8e1fe4&pvs=4';
+      expect(() => repository.getPageIdFromPageUrl({ pageUrl })).toThrow('Notion Databases are not supported yet. Please use a Notion Page URL');
+    });
+
+    it('should extract the page ID from a URL with direct ID and query parameters', () => {
+      const pageUrl = 'https://www.notion.so/16d4754ea1e980d1a2fdc2ab5fa4dfaf?pvs=4';
+      const result = repository.getPageIdFromPageUrl({ pageUrl });
+      expect(result).toBe('16d4754ea1e980d1a2fdc2ab5fa4dfaf');
+    });
+  });
 
 }); 

--- a/src/infrastructure/notion/notion.destination.ts
+++ b/src/infrastructure/notion/notion.destination.ts
@@ -44,6 +44,39 @@ export class NotionDestinationRepository
     this.notionConverter = notionConverter;
   }
 
+  getPageIdFromPageUrl({ pageUrl }: { pageUrl: string }): string {
+    const urlObj = new URL(pageUrl);
+
+    const pathSegments = urlObj.pathname.split('-');
+    let lastSegment = pathSegments[pathSegments.length - 1];
+
+    /**
+     * If the URL has a query parameter `v`, it's becase it's a Notion Database
+     * Unfortunatly, for now, mk-notes doesn't support Notion Databases
+     **/
+    if (urlObj.searchParams.has('v')) {
+      throw new Error(
+        'Notion Databases are not supported yet. Please use a Notion Page URL'
+      );
+    }
+
+    if (lastSegment.startsWith('/')) {
+      lastSegment = lastSegment.slice(1);
+    }
+
+    const [lastSegmentWithoutQueryParams] = lastSegment.split('?');
+
+    if (!lastSegmentWithoutQueryParams) {
+      throw new Error('Invalid Notion URL');
+    }
+
+    if (lastSegmentWithoutQueryParams.length !== 32) {
+      throw new Error('Invalid Notion URL');
+    }
+
+    return lastSegmentWithoutQueryParams;
+  }
+
   async destinationIsAccessible({
     parentPageId,
   }: {


### PR DESCRIPTION
## Summary

This PR refactors the Notion page URL handling by moving the `getPageIdFromPageUrl` method from the 
`SynchronizeMarkdownToNotion` class to the `NotionDestinationRepository` class, making it a required method in the DestinationRepository interface.

### Changes
#### Code Refactoring

- Moved `getPageIdFromPageUrl` method from `SynchronizeMarkdownToNotion` to `NotionDestinationRepository`
- Added the method to the `DestinationRepository` interface
- Implemented the method in `FakeDestinationRepository` for testing purposes
- Enhanced URL parsing logic to handle more URL formats and edge cases

#### Improved URL Validation
- Added specific detection and error handling for Notion Database URLs
- Better validation for page ID formats and URL structures
- Improved error messages to guide users

#### Testing
- Moved and expanded tests for the `getPageIdFromPageUrl` method
- Added tests for various URL formats and edge cases
- Re-enabled the main `NotionDestinationRepository` test suite while keeping individual method tests skipped

#### Documentation
- Added a warning in the documentation about Notion Databases not being supported
- User Experience Improvements
- Users will now see clearer error messages when attempting to use unsupported Notion Database URLs
- Documentation now explicitly states the limitation regarding Notion Databases

This PR ensures more reliable handling of Notion page URLs and provides better feedback to users when they try to use an unsupported feature.