### PR TITLE
fix(issue-8): split page blocks creation in multiple calls 

### DIFF
--- a/docs/docs/getting-started/1-your-first-synchronization.md
+++ b/docs/docs/getting-started/1-your-first-synchronization.md
@@ -37,12 +37,12 @@ Launch the following command:
   mk-notes sync \
     --input <path-where-your-markdown-files-are> \
     --destination <notion-page-url> \
-    --notion-api-token <your-notion-secret>
+    --notion-api-key <your-notion-secret>
 ```
 
 - `--input` : The path where your markdown files are located.
 - `--destination` : The Notion page URL where you want to synchronize your markdown files.
-- `--notion-api-token` : Your Notion secret token.
+- `--notion-api-key` : Your Notion secret token.
 
 :::warning
 Please note that you can only synchronize markdown files to **Notion Pages**. Notion Databases are not supported for now.


### PR DESCRIPTION
Linked to #8 

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

## Description

This PR includes two main changes:

1. **Documentation Update**: 
   - Updated the CLI parameter name from `--notion-api-token` to `--notion-api-key` in the getting started documentation to maintain consistency with the codebase.

2. **Performance Improvement in Notion Integration**:
   - Added handling for Notion's block limit constraint (100 blocks per request)
   - Modified page creation process to:
     - First create the page without children
     - Then append children blocks in chunks of 100
   - This change prevents potential issues with large page synchronizations

### Checklist:
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

The changes improve reliability when synchronizing large markdown files to Notion and provide clearer documentation for users.