### PR TITLE
Use Folder Name for index.md and Remove .md Extension from Notion Page Titles

### DIFF
--- a/src/infrastructure/filesystem/fileSystem.source.test.ts
+++ b/src/infrastructure/filesystem/fileSystem.source.test.ts
@@ -110,7 +110,7 @@ describe('FileSystemSourceRepository', () => {
       const result = await repository.getFile({ path: '/test/path/file.md' });
 
       expect(result).toEqual({
-        name: 'file.md',
+        name: 'file',
         content: 'file content',
         extension: 'md',
         lastUpdated: mockDate

--- a/src/infrastructure/filesystem/fileSystem.source.ts
+++ b/src/infrastructure/filesystem/fileSystem.source.ts
@@ -76,8 +76,23 @@ export class FileSystemSourceRepository
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async getFile({ path }: { path: string }): Promise<File> {
+    // Determine the display name for the Notion page
+    const base = basename(path);
+    let name = base;
+    if (base.toLowerCase() === 'index.md') {
+      // Use parent folder name for index.md
+      const parts = path.split(/[\\/]/); // handle both / and \
+      if (parts.length > 1) {
+        name = parts[parts.length - 2];
+      } else {
+        name = 'index'; // fallback if no parent
+      }
+    } else if (base.toLowerCase().endsWith('.md')) {
+      // Remove .md extension for all other files
+      name = base.slice(0, -3);
+    }
     return {
-      name: basename(path),
+      name,
       content: readFileSync(path, 'utf-8'),
       extension: extname(path).slice(1),
       lastUpdated: this.getLastUpdatedDate(path),


### PR DESCRIPTION
### Summary

This PR addresses and resolves [#11](https://github.com/Myastr0/mk-notes/issues/11):

- **For `index.md` files:** The Notion page title is now set to the parent folder’s name instead of `index.md`.
- **For all markdown files:** The `.md` extension is stripped from the Notion page title, resulting in cleaner, more user-friendly page names in Notion.

### Details

- Updated the `FileSystemSourceRepository.getFile` method to:
  - Detect when a file is `index.md` and set its name to the parent directory.
  - Remove the `.md` extension from all other markdown file names.
- Adjusted tests to reflect the new naming logic.

### Why

Previously, when syncing, folders with an `index.md` would appear in Notion as `index.md` instead of the folder name, and all page titles included the `.md` extension. This was confusing and cluttered the Notion workspace. The new logic ensures that:
- Section pages are named after their folder (if using `index.md`).
- All page titles are clean and do not include file extensions.

### How to Test

1. Create a directory structure with nested folders and `index.md` files, as described in the original issue.
2. Run the sync or preview command.
3. Verify that:
   - Pages for `index.md` are named after their parent folder.
   - No page titles include the `.md` extension.

---

Closes #11

---
