### PR TITLE
Split Long Paragraphs to Comply with Notion 2000-Character Limit

### DIFF
--- a/src/infrastructure/notion/notion.converter.ts
+++ b/src/infrastructure/notion/notion.converter.ts
@@ -399,14 +399,18 @@ export class NotionConverterRepository
     }
 
     if (typeof content === 'string') {
-      return [
-        {
-          type: 'text',
-          text: {
-            content: content,
-          },
+      // Split string into chunks of 2000 characters
+      const MAX_LENGTH = 2000;
+      const chunks: string[] = [];
+      for (let i = 0; i < content.length; i += MAX_LENGTH) {
+        chunks.push(content.slice(i, i + MAX_LENGTH));
+      }
+      return chunks.map((chunk) => ({
+        type: 'text',
+        text: {
+          content: chunk,
         },
-      ];
+      }));
     }
 
     if (Array.isArray(content)) {


### PR DESCRIPTION
## Fix: Split Long Paragraphs to Comply with Notion 2000-Character Limit

### Summary

This PR resolves [#10](https://github.com/Myastr0/mk-notes/issues/10):

- **Problem:** Notion API rejects paragraph blocks where any single `rich_text` item exceeds 2000 characters, causing sync errors for long paragraphs.
- **Solution:** The conversion logic now splits any paragraph text longer than 2000 characters into multiple `rich_text` items, each within the allowed limit.

### Details

- Updated the `convertRichText` method in `NotionConverterRepository` to chunk string content into 2000-character segments before creating `rich_text` items.
- This ensures that even very long paragraphs are accepted by the Notion API and no validation errors occur.

### Why

Previously, syncing markdown files with very long paragraphs would fail due to Notion's API limit. This fix ensures robust handling of large content and improves user experience.

### How to Test

1. Create a markdown file with a single paragraph longer than 2000 characters.
2. Run the sync or preview command.
3. Verify that the sync completes successfully and the content appears correctly in Notion.

---

Closes #10

---
