### PR TITLE
feat: add support for inline code formatting with single backticks

### DIFF
--- a/src/domains/elements/Element.ts
+++ b/src/domains/elements/Element.ts
@@ -149,6 +149,7 @@ export type TextElementStyles = {
   bold: boolean;
   strikethrough: boolean;
   underline: boolean;
+  code: boolean;
 };
 
 export class TextElement extends Element {
@@ -159,6 +160,7 @@ export class TextElement extends Element {
     bold: false,
     strikethrough: false,
     underline: false,
+    code: false,
   };
 
   constructor({
@@ -173,6 +175,7 @@ export class TextElement extends Element {
       bold?: boolean;
       strikethrough?: boolean;
       underline?: boolean;
+      code?: boolean;
     };
   }) {
     super(ElementType.Text);
@@ -182,6 +185,7 @@ export class TextElement extends Element {
     this.styles.italic = styles?.italic || false;
     this.styles.strikethrough = styles?.strikethrough || false;
     this.styles.underline = styles?.underline || false;
+    this.styles.code = styles?.code || false;
   }
 }
 
@@ -419,6 +423,7 @@ export class EquationElement extends Element {
     bold: false,
     strikethrough: false,
     underline: false,
+    code: false,
   };
 
   constructor({
@@ -431,6 +436,7 @@ export class EquationElement extends Element {
       bold?: boolean;
       strikethrough?: boolean;
       underline?: boolean;
+      code?: boolean;
     };
   }) {
     super(ElementType.Equation);
@@ -439,5 +445,6 @@ export class EquationElement extends Element {
     this.styles.italic = styles?.italic || false;
     this.styles.strikethrough = styles?.strikethrough || false;
     this.styles.underline = styles?.underline || false;
+    this.styles.code = styles?.code || false;
   }
 }

--- a/src/infrastructure/markdown/markdown.parser.test.ts
+++ b/src/infrastructure/markdown/markdown.parser.test.ts
@@ -89,6 +89,56 @@ describe('MarkdownParser', () => {
       ]);
     });
 
+    it('should parse inline code with single backticks', () => {
+      const markdown = `
+This is normal text with \`inline code\` and more text.
+Another line with \`code\` and **bold \`code in bold\`** text.
+`;
+
+      const result = parser.parse({ content: markdown });
+
+      expect(result.content).toHaveLength(1);
+
+      assert(result.content[0] instanceof TextElement);
+      const textElement = result.content[0] as TextElement;
+      
+      expect(textElement).toBeInstanceOf(TextElement);
+      
+      // Check that we have the right structure based on actual parsed output
+      expect(textElement.text).toHaveLength(7);
+      
+      // First text: "This is normal text with "
+      const text1 = textElement.text[0] as TextElement;
+      expect(text1).toBeInstanceOf(TextElement);
+      expect(text1).toMatchObject({ 
+        text: 'This is normal text with ', 
+        styles: { bold: false, italic: false, strikethrough: false, underline: false, code: false } 
+      });
+      
+      // First inline code: "inline code" - THIS IS THE KEY TEST!
+      const codeElement1 = textElement.text[1] as TextElement;
+      expect(codeElement1).toBeInstanceOf(TextElement);
+      expect(codeElement1).toMatchObject({ 
+        text: 'inline code', 
+        styles: { bold: false, italic: false, strikethrough: false, underline: false, code: true } 
+      });
+      
+      // Text between: " and more text.\n\nAnother line with "  
+      const text2 = textElement.text[2] as TextElement;
+      expect(text2).toBeInstanceOf(TextElement);
+      expect(text2.styles).toMatchObject({ 
+        bold: false, italic: false, strikethrough: false, underline: false, code: false
+      });
+      
+      // Second inline code: "code" - ANOTHER KEY TEST!
+      const codeElement2 = textElement.text[3] as TextElement;
+      expect(codeElement2).toBeInstanceOf(TextElement);
+      expect(codeElement2).toMatchObject({ 
+        text: 'code', 
+        styles: { bold: false, italic: false, strikethrough: false, underline: false, code: true } 
+      });
+    });
+
     it('should parse lists', () => {
       const markdown = `
 - Unordered item 1

--- a/src/infrastructure/markdown/markdown.parser.ts
+++ b/src/infrastructure/markdown/markdown.parser.ts
@@ -182,7 +182,12 @@ export class MarkdownParser extends ParserRepository {
   }
 
   private parseTextToken(
-    token: Tokens.Text | Tokens.Strong | Tokens.Em | Tokens.Del
+    token:
+      | Tokens.Text
+      | Tokens.Strong
+      | Tokens.Em
+      | Tokens.Del
+      | Tokens.Codespan
   ): TextElement {
     if (token.type === 'strong') {
       return new TextElement({
@@ -192,6 +197,7 @@ export class MarkdownParser extends ParserRepository {
           italic: false,
           strikethrough: false,
           underline: false,
+          code: false,
         },
       });
     }
@@ -204,6 +210,7 @@ export class MarkdownParser extends ParserRepository {
           italic: true,
           strikethrough: false,
           underline: false,
+          code: false,
         },
       });
     }
@@ -212,7 +219,24 @@ export class MarkdownParser extends ParserRepository {
       return new TextElement({
         text: token.text,
         styles: {
+          bold: false,
+          italic: false,
           strikethrough: true,
+          underline: false,
+          code: false,
+        },
+      });
+    }
+
+    if (token.type === 'codespan') {
+      return new TextElement({
+        text: token.text,
+        styles: {
+          bold: false,
+          italic: false,
+          strikethrough: false,
+          underline: false,
+          code: true,
         },
       });
     }
@@ -272,6 +296,9 @@ export class MarkdownParser extends ParserRepository {
           break;
         case 'del':
           elements.push(this.parseTextToken(t as Tokens.Del));
+          break;
+        case 'codespan':
+          elements.push(this.parseTextToken(t as Tokens.Codespan));
           break;
         case 'link':
           elements.push(this.parseLinkToken(t as Tokens.Link));

--- a/src/infrastructure/notion/notion.converter.ts
+++ b/src/infrastructure/notion/notion.converter.ts
@@ -467,6 +467,7 @@ export class NotionConverterRepository
               italic: (element as TextElement).styles.italic,
               strikethrough: (element as TextElement).styles.strikethrough,
               underline: (element as TextElement).styles.underline,
+              code: (element as TextElement).styles.code,
             },
           });
         }
@@ -494,6 +495,7 @@ export class NotionConverterRepository
               italic: element.styles.italic,
               strikethrough: element.styles.strikethrough,
               underline: element.styles.underline,
+              code: element.styles.code,
             },
           });
         }


### PR DESCRIPTION
- Add 'code' property to TextElementStyles interface
- Update markdown parser to handle 'codespan' tokens
- Update Notion converter to support code annotations
- Enable proper rendering of `inline code` in Notion

Fixes single backtick code formatting that was previously not supported.

All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
