### PR TITLE
docs(#57): remove gha tag ref in docs

### DIFF
--- a/docs/content/docs/github-actions/available-actions/1-preview-action.mdx
+++ b/docs/content/docs/github-actions/available-actions/1-preview-action.mdx
@@ -14,7 +14,7 @@ steps:
     uses: actions/checkout@v4
 
   - name: Preview markdown synchronization
-    uses: Myastr0/mk-notes/preview@v1
+    uses: Myastr0/mk-notes/preview
     with:
       input: './docs' # The path to the markdown file or directory to preview
       format: 'plainText' # The format of the preview ("plainText" or "json")
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Preview synchronization
-        uses: Myastr0/mk-notes/preview@v1
+        uses: Myastr0/mk-notes/preview
         with:
           input: './docs'
           format: 'plainText'
@@ -68,7 +68,7 @@ jobs:
 
       - name: Sync to Notion
         if: github.event_name == 'push'
-        uses: Myastr0/mk-notes/sync@v1
+        uses: Myastr0/mk-notes/sync
         with:
           input: './docs'
           destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate JSON preview
-        uses: Myastr0/mk-notes/preview@v1
+        uses: Myastr0/mk-notes/preview
         with:
           input: './docs'
           format: 'json'

--- a/docs/content/docs/github-actions/available-actions/2-sync-action.mdx
+++ b/docs/content/docs/github-actions/available-actions/2-sync-action.mdx
@@ -14,7 +14,7 @@ steps:
     uses: actions/checkout@v4
 
   - name: Sync markdown to Notion
-    uses: Myastr0/mk-notes/sync@v1
+    uses: Myastr0/mk-notes/sync
     with:
       input: './docs' # The path to the markdown file or directory to synchronize
       destination: 'https://notion.so/your-page-id'
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync documentation to Notion
-        uses: Myastr0/mk-notes/sync@v1
+        uses: Myastr0/mk-notes/sync
         with:
           input: './docs'
           destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync to Notion
-        uses: Myastr0/mk-notes/sync@v1
+        uses: Myastr0/mk-notes/sync
         with:
           input: './docs'
           destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clean sync to Notion
-        uses: Myastr0/mk-notes/sync@v1
+        uses: Myastr0/mk-notes/sync
         with:
           input: './content'
           destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}

--- a/docs/content/docs/github-actions/best-practices.mdx
+++ b/docs/content/docs/github-actions/best-practices.mdx
@@ -10,14 +10,14 @@ Always use the preview action before syncing to verify the structure:
 
 ```yaml
 - name: Preview changes
-  uses: Myastr0/mk-notes/preview@v1
+  uses: Myastr0/mk-notes/preview
   with:
     input: './docs'
     format: 'plainText'
 
 - name: Sync to Notion
   if: github.ref == 'refs/heads/main'
-  uses: Myastr0/mk-notes/sync@v1
+  uses: Myastr0/mk-notes/sync
   with:
     input: './docs'
     destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}
@@ -58,7 +58,7 @@ Consider using different Notion pages for different branches:
 
 ```yaml
 - name: Sync to Notion
-  uses: Myastr0/mk-notes/sync@v1
+  uses: Myastr0/mk-notes/sync
   with:
     input: './docs'
     destination: ${{ github.ref == 'refs/heads/main' && secrets.NOTION_MAIN_DOCS_PAGE_URL || secrets.NOTION_DEV_DOCS_PAGE_URL }}
@@ -89,7 +89,7 @@ Add proper error handling to your workflows:
 
 ```yaml
 - name: Sync to Notion
-  uses: Myastr0/mk-notes/sync@v1
+  uses: Myastr0/mk-notes/sync
   with:
     input: './docs'
     destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}

--- a/docs/content/docs/github-actions/troubleshooting.mdx
+++ b/docs/content/docs/github-actions/troubleshooting.mdx
@@ -98,7 +98,7 @@ Always use the preview action to verify structure before syncing:
 
 ```yaml
 - name: Preview synchronization
-  uses: Myastr0/mk-notes/preview@v1
+  uses: Myastr0/mk-notes/preview
   with:
     input: './docs'
     format: 'plainText'


### PR DESCRIPTION
Fixes #57 

All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

## Description

This PR removes version tags (`@v1`) from all GitHub Actions examples in the documentation. The changes update all references from:
- `Myastr0/mk-notes/preview@v1` → `Myastr0/mk-notes/preview`
- `Myastr0/mk-notes/sync@v1` → `Myastr0/mk-notes/sync`

## Changes Made

Updated documentation files to remove version tags from GitHub Actions usage:
- `docs/content/docs/github-actions/available-actions/1-preview-action.mdx` - Removed `@v1` from all preview action examples
- `docs/content/docs/github-actions/available-actions/2-sync-action.mdx` - Removed `@v1` from all sync action examples
- `docs/content/docs/github-actions/best-practices.mdx` - Removed `@v1` from best practice examples
- `docs/content/docs/github-actions/troubleshooting.mdx` - Removed `@v1` from troubleshooting examples

## Why This Change?

Removing version tags allows GitHub Actions to automatically use the latest version of the actions, ensuring users always have access to the most recent features and bug fixes without needing to manually update version numbers in their workflows.

## Testing

- [x] Documentation changes only - no code changes
- [x] Verified all examples are syntactically correct
- [x] Confirmed consistency across all documentation files

