### PR TITLE
Add --flat option for database syncs

### DIFF
--- a/__tests__/__fakes__/fakeDestination.repository.ts
+++ b/__tests__/__fakes__/fakeDestination.repository.ts
@@ -152,4 +152,15 @@ export class FakeDestinationRepository<T extends Page>
     // no-op in fake repository for testing
     return Promise.resolve();
   }
+
+  async deletePagesInDatabaseByInternalId({
+    databaseId,
+    mkNotesInternalId,
+  }: {
+    databaseId: string;
+    mkNotesInternalId: string;
+  }): Promise<void> {
+    // no-op in fake repository for testing
+    return Promise.resolve();
+  }
 }

--- a/docs/content/docs/cli/guides/cli-commands.mdx
+++ b/docs/content/docs/cli/guides/cli-commands.mdx
@@ -48,6 +48,8 @@ mk-notes sync -i <path> -d <notionUrl> -k <notionApiKey>
 
 - `-l, --lock`: Lock the Notion page after syncing to prevent further editing. This is useful when you want to preserve the synchronized content and prevent accidental modifications.
 
+- `-f, --flat`: **Database destination only** - Flattens the directory structure so all markdown files are created as direct children of the database, not nested as child pages. This option is only available when the destination is a Notion database. If used with a page destination, an error will be thrown.
+
 ### Destination Types
 
 Mk Notes supports two types of destinations:
@@ -191,6 +193,31 @@ This command will:
 1. Find existing pages in the database with matching `mk-notes-id` property
 2. Delete those existing pages
 3. Create new pages as database items with the content from your markdown files
+
+#### Flat Sync to a Database
+
+```bash
+mk-notes sync \
+  --input ./my-docs \
+  --destination https://notion.so/myworkspace/database-123456 \
+  --notion-api-key secret_abc123... \
+  --flat
+```
+
+The `--flat` option creates all markdown files as direct children of the database, ignoring the directory structure. This is useful when you want a flat list of all documents in your database without nested page hierarchies.
+
+This command will:
+
+1. Read all markdown files in the directory
+2. Flatten the directory structure
+3. Create all files as direct database items (no nested pages)
+4. Each file becomes a separate database entry
+
+<Callout type="warning" title="Database Only">
+
+The `--flat` option only works with database destinations. If you try to use it with a page destination, MK Notes will throw an error.
+
+</Callout>
 
 ## `preview-sync`
 

--- a/docs/content/docs/cli/guides/database-sync.mdx
+++ b/docs/content/docs/cli/guides/database-sync.mdx
@@ -134,6 +134,45 @@ Clean sync only works for pages that have an `id` defined in their frontmatter. 
 
 </Callout>
 
+### Flat Sync
+
+By default, MK Notes preserves your directory structure when syncing to a database, creating nested pages for subdirectories. The `--flat` option flattens this structure, creating all markdown files as direct children of the database:
+
+```bash
+mk-notes sync \
+  --input ./docs \
+  --destination https://notion.so/myworkspace/database-123456 \
+  --notion-api-key secret_abc123... \
+  --flat
+```
+
+**When to use flat sync:**
+
+- You want all documents at the same level in your database
+- You prefer to organize using database views and filters rather than page hierarchies
+- Your directory structure is just for file organization, not content hierarchy
+
+**Example:**
+
+With a directory structure like:
+```
+docs/
+  guides/
+    getting-started.md
+    advanced.md
+  api/
+    authentication.md
+```
+
+- **Without `--flat`**: Creates nested pages (guides → getting-started, advanced)
+- **With `--flat`**: Creates all four files as direct database entries
+
+<Callout type="warning" title="Database Only">
+
+The `--flat` option only works with database destinations. Using it with a page destination will result in an error.
+
+</Callout>
+
 ---
 
 ## Adding Custom Database Properties

--- a/preview/index.js
+++ b/preview/index.js
@@ -75002,7 +75002,7 @@ class MkNotes {
     /**
      * Preview the synchronization of a markdown file to Notion
      */
-    async previewSynchronization({ inputPath, format, output, }) {
+    async previewSynchronization({ inputPath, format, output, flat = false, }) {
         const previewSynchronizationFeature = new domains_1.PreviewSynchronization({
             sourceRepository: this.infrastructureInstances.fileSystemSource,
         });
@@ -75010,6 +75010,7 @@ class MkNotes {
             path: inputPath,
         }, {
             format,
+            flat,
         });
         if (!output) {
             return result;
@@ -75020,7 +75021,7 @@ class MkNotes {
     /**
      * Synchronize a markdown file to Notion
      */
-    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, }) {
+    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, flat = false, }) {
         const synchronizeMarkdownToNotion = new domains_1.SynchronizeMarkdownToNotion({
             logger: this.logger,
             destinationRepository: this.infrastructureInstances.notionDestination,
@@ -75032,6 +75033,7 @@ class MkNotes {
             notionParentPageUrl: parentNotionPageId,
             cleanSync,
             lockPage,
+            flat,
         });
     }
 }
@@ -75812,7 +75814,7 @@ class PreviewSynchronization {
     constructor(params) {
         this.sourceRepository = params.sourceRepository;
     }
-    async execute(args, { format } = {}) {
+    async execute(args, { format, flat = false, } = {}) {
         // Check if the GitHub repository is accessible
         try {
             await this.sourceRepository.sourceIsAccessible(args);
@@ -75840,6 +75842,9 @@ class PreviewSynchronization {
         }
         const filePaths = await this.sourceRepository.getFilePathList(args);
         const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+        if (flat) {
+            siteMap.flatten();
+        }
         return sitemapSerializer(siteMap);
     }
 }
@@ -75869,7 +75874,7 @@ class SynchronizeMarkdownToNotion {
         this.logger = params.logger;
     }
     async execute(args) {
-        const { notionParentPageUrl, cleanSync, lockPage, ...others } = args;
+        const { notionParentPageUrl, cleanSync, lockPage, flat = false, ...others } = args;
         const notionObjectId = this.destinationRepository.getObjectIdFromObjectUrl({
             objectUrl: notionParentPageUrl,
         });
@@ -75899,6 +75904,9 @@ class SynchronizeMarkdownToNotion {
             this.logger.info('Starting synchronization process');
             const filePaths = await this.sourceRepository.getFilePathList(others);
             const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+            if (flat && parentObjectType === 'database') {
+                siteMap.flatten();
+            }
             // Traverse the SiteMap and synchronize files
             await this.synchronizeTreeNode({
                 node: siteMap.root,
@@ -75906,6 +75914,7 @@ class SynchronizeMarkdownToNotion {
                 parentObjectType,
                 lockPage,
                 cleanSync,
+                flat,
             });
             this.logger.info('Synchronization process completed successfully');
         }
@@ -75995,32 +76004,19 @@ class SynchronizeMarkdownToNotion {
         return newPage.pageId;
     }
     async cleanSyncDatabase({ databaseId, pageElement, }) {
-        const dataSourceId = await this.destinationRepository.getDataSourceIdFromDatabaseId({
-            databaseId,
-        });
         if (pageElement.mkNotesInternalId === undefined) {
             this.logger.warn('mk-notes-internal-id is undefined, skipping clean sync');
             return;
         }
-        const objectIds = await this.destinationRepository.getObjectIdInDatabaseByMkNotesInternalId({
-            dataSourceId,
+        await this.destinationRepository.deletePagesInDatabaseByInternalId({
+            databaseId,
             mkNotesInternalId: pageElement.mkNotesInternalId,
         });
-        if (objectIds.length === 0) {
-            this.logger.warn('No object IDs found, skipping clean sync');
-            return;
-        }
-        if (objectIds.length > 1) {
-            this.logger.info(`Multiple object IDs found with ${pageElement.mkNotesInternalId}, deleting all objects`);
-        }
-        await Promise.all(objectIds.map(async (objectId) => this.destinationRepository.deleteObjectById({
-            objectId,
-        })));
     }
     /**
      * Synchronizes a child node and its descendants recursively
      */
-    async synchronizeChildNode({ childNode, parentPageId, lockPage, }) {
+    async synchronizeChildNode({ childNode, parentPageId, lockPage, cleanSync, parentObjectType = 'page', }) {
         const filePath = childNode.filepath;
         this.logger.info(`Processing file: ${filePath}`);
         const pageElement = await this.fetchAndConvertToPageElement(filePath);
@@ -76030,10 +76026,22 @@ class SynchronizeMarkdownToNotion {
         if (childNode.children.length > 0) {
             pageElement.addElementToEnd(new elements_1.DividerElement());
         }
+        // If parent is a database (e.g. in flat sync), we need to clean up previous version of this specific page
+        if (parentObjectType === 'database' && cleanSync) {
+            if (!pageElement.mkNotesInternalId) {
+                this.logger.warn('mk-notes-internal-id is undefined, skipping clean sync for child node');
+            }
+            else {
+                await this.destinationRepository.deletePagesInDatabaseByInternalId({
+                    databaseId: parentPageId,
+                    mkNotesInternalId: pageElement.mkNotesInternalId,
+                });
+            }
+        }
         const newPage = await this.destinationRepository.createPage({
             pageElement,
             parentObjectId: parentPageId,
-            parentObjectType: 'page',
+            parentObjectType,
             filePath,
         });
         this.logger.info(`Created Notion page for file: ${filePath}`);
@@ -76046,6 +76054,7 @@ class SynchronizeMarkdownToNotion {
                 childNode: grandChild,
                 parentPageId: newPage.pageId,
                 lockPage,
+                cleanSync,
             });
         }
         await this.lockPageIfNeeded(newPage.pageId, lockPage);
@@ -76053,29 +76062,65 @@ class SynchronizeMarkdownToNotion {
     /**
      * Main orchestrator for synchronizing a tree node and its children
      */
-    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, }) {
+    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, flat = false, }) {
         let parentPageId = parentObjectId;
+        if (flat && parentObjectType !== 'database') {
+            this.logger.warn('Flat option ignored because destination is not a database');
+        }
+        const isFlatSync = flat && parentObjectType === 'database';
+        // If flat sync is enabled, flatten the sitemap starting from this node
+        // Since we are passing the root node here usually, this affects the whole tree
+        // But we rely on SiteMap.flatten() which works on the whole structure anyway if we had access to SiteMap
+        // Here we only have the root node. But wait, SiteMap.flatten() modifies the tree structure in place.
+        // Since we don't have the SiteMap instance here, we can implement a helper or just assume
+        // the caller has done it? No, the plan says "If flat is true, call siteMap.flatten() immediately."
+        // But we don't have the siteMap instance here.
+        // Correction: We call synchronizeTreeNode with siteMap.root.
+        // We should probably move the flatten call to `execute` BEFORE calling synchronizeTreeNode.
+        // BUT `execute` has the SiteMap instance!
+        // Let's revert to the plan: "In synchronizeTreeNode: If flat is true, call siteMap.flatten() immediately."
+        // Ah, `synchronizeTreeNode` receives a `node`. It doesn't have the `SiteMap` instance.
+        // The `execute` method has the `SiteMap` instance.
+        // So I will modify `execute` instead to flatten the map.
+        // Wait, I already modified `execute` but didn't add the flatten call there.
+        // I will add the flatten logic in `execute` in a separate tool call.
         switch (parentObjectType) {
             case 'unknown':
                 throw new Error('Parent object type is unknown');
             case 'database':
-                if (this.getIsRootNode(node)) {
-                    parentPageId = await this.synchronizeRootNode({
-                        node,
-                        parentObjectId,
-                        parentObjectType,
-                        lockPage,
-                        cleanSync,
-                    });
+                if (isFlatSync) {
+                    // In flat sync, if the root has content, we sync it to the DB.
+                    if (this.getIsRootNode(node)) {
+                        await this.synchronizeRootNode({
+                            node,
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
+                    // Children will also be synced to the DB (parentObjectId)
+                    parentPageId = parentObjectId;
                 }
                 else {
-                    parentPageId = await this.synchronizeRootNode({
-                        node: node.children[0],
-                        parentObjectId,
-                        parentObjectType,
-                        lockPage,
-                        cleanSync,
-                    });
+                    if (this.getIsRootNode(node)) {
+                        parentPageId = await this.synchronizeRootNode({
+                            node,
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
+                    else {
+                        parentPageId = await this.synchronizeRootNode({
+                            node: node.children[0],
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
                 }
                 break;
             case 'page':
@@ -76098,6 +76143,8 @@ class SynchronizeMarkdownToNotion {
                     childNode,
                     parentPageId,
                     lockPage,
+                    cleanSync,
+                    parentObjectType: isFlatSync ? 'database' : 'page',
                 });
             }
             catch (error) {
@@ -76482,7 +76529,12 @@ class SiteMap {
     removeUselessNodesTree(node) {
         while (node.children.length === 1 &&
             path.extname(node.children[0].filepath) === '') {
-            node.children = node.children[0].children;
+            const [child] = node.children;
+            node.children = child.children;
+            // Fix parent pointers for the adopted children
+            node.children.forEach((grandChild) => {
+                grandChild.parent = node;
+            });
         }
         return node;
     }
@@ -76492,6 +76544,32 @@ class SiteMap {
     _updateTree() {
         this.removeUselessNodesTree(this._root);
         this.traverseAndUpdate(this._root);
+    }
+    /**
+     * Flattens the sitemap structure so all files are direct children of the root.
+     * This is useful for flat synchronization mode.
+     */
+    flatten() {
+        const allNodes = [];
+        // Collect all nodes except root
+        const collectNodes = (node) => {
+            // We don't include the current node if it's the root
+            if (node !== this._root) {
+                allNodes.push(node);
+            }
+            node.children.forEach(collectNodes);
+        };
+        // Start collection from root's children
+        this._root.children.forEach(collectNodes);
+        // Clear existing children of root
+        this._root.children = [];
+        // Reassign all collected nodes as direct children of root
+        // And clear their children since they are now flat
+        allNodes.forEach((node) => {
+            node.parent = this._root;
+            node.children = [];
+            this._root.children.push(node);
+        });
     }
     /**
      * TODO: Implement mkdocs.yaml sitemap parsing
@@ -79172,6 +79250,25 @@ class NotionDestinationRepository {
             },
         });
         return items.results.map((item) => item.id);
+    }
+    async deletePagesInDatabaseByInternalId({ databaseId, mkNotesInternalId, }) {
+        const dataSourceId = await this.getDataSourceIdFromDatabaseId({
+            databaseId,
+        });
+        const objectIds = await this.getObjectIdInDatabaseByMkNotesInternalId({
+            dataSourceId,
+            mkNotesInternalId,
+        });
+        if (objectIds.length === 0) {
+            this.logger.warn('No object IDs found, skipping clean sync');
+            return;
+        }
+        if (objectIds.length > 1) {
+            this.logger.info(`Multiple object IDs found with ${mkNotesInternalId}, deleting all objects`);
+        }
+        await Promise.all(objectIds.map(async (objectId) => this.deleteObjectById({
+            objectId,
+        })));
     }
     async deleteObjectById({ objectId }) {
         await this.client.blocks.delete({ block_id: objectId });

--- a/src/MkNotes.ts
+++ b/src/MkNotes.ts
@@ -48,10 +48,12 @@ export class MkNotes {
     inputPath,
     format,
     output,
+    flat = false,
   }: {
     inputPath: string;
     format: PreviewFormat;
     output?: string;
+    flat?: boolean;
   }): Promise<string> {
     const previewSynchronizationFeature = new PreviewSynchronization({
       sourceRepository: this.infrastructureInstances.fileSystemSource,
@@ -63,6 +65,7 @@ export class MkNotes {
       },
       {
         format,
+        flat,
       }
     );
 
@@ -83,11 +86,13 @@ export class MkNotes {
     parentNotionPageId,
     cleanSync = false,
     lockPage = false,
+    flat = false,
   }: {
     inputPath: string;
     parentNotionPageId: string;
     cleanSync?: boolean;
     lockPage?: boolean;
+    flat?: boolean;
   }): Promise<void> {
     const synchronizeMarkdownToNotion = new SynchronizeMarkdownToNotion({
       logger: this.logger,
@@ -101,6 +106,7 @@ export class MkNotes {
       notionParentPageUrl: parentNotionPageId,
       cleanSync,
       lockPage,
+      flat,
     });
   }
 }

--- a/src/bin/cli/commands/preview.ts
+++ b/src/bin/cli/commands/preview.ts
@@ -53,6 +53,11 @@ command.addOption(
 
 command.option('-o, --output <output>', 'Output file path');
 
+command.option(
+  '--flat',
+  'Flat sync - If destination is a database, all files will be created as direct children of the database, not nested'
+);
+
 command.option('-v, --verbosity <verbosity>', 'Verbosity level', 'error');
 
 interface PreviewOptions {
@@ -60,9 +65,16 @@ interface PreviewOptions {
   format: PreviewFormat;
   output?: string;
   verbosity?: string;
+  flat?: boolean;
 }
 command.action(async (opts: PreviewOptions) => {
-  const { input: directoryPath, format, output, verbosity = 'error' } = opts;
+  const {
+    input: directoryPath,
+    format,
+    output,
+    verbosity = 'error',
+    flat = false,
+  } = opts;
 
   if (!isValidVerbosity(verbosity)) {
     throw new Error(`Invalid verbosity: ${verbosity}`);
@@ -77,6 +89,7 @@ command.action(async (opts: PreviewOptions) => {
     inputPath: directoryPath,
     format,
     output,
+    flat,
   });
 
   // eslint-disable-next-line no-console

--- a/src/bin/cli/commands/sync.ts
+++ b/src/bin/cli/commands/sync.ts
@@ -34,6 +34,11 @@ command.option(
 
 command.option('-l, --lock', 'Lock the Notion page after syncing');
 
+command.option(
+  '-f, --flat',
+  'Flat sync - If destination is a database, all files will be created as direct children of the database, not nested'
+);
+
 command.option('-v, --verbosity <verbosity>', 'Verbosity level', 'error');
 interface SyncOptions {
   input: string;
@@ -42,6 +47,7 @@ interface SyncOptions {
   clean?: boolean;
   lock?: boolean;
   verbosity?: string;
+  flat?: boolean;
 }
 
 command.action(async (opts: SyncOptions) => {
@@ -52,6 +58,7 @@ command.action(async (opts: SyncOptions) => {
     clean = false,
     lock = false,
     verbosity = 'error',
+    flat = false,
   } = opts;
 
   if (!isValidVerbosity(verbosity)) {
@@ -68,6 +75,7 @@ command.action(async (opts: SyncOptions) => {
     parentNotionPageId: notionParentPageUrl,
     cleanSync: clean,
     lockPage: lock,
+    flat,
   });
 
   // eslint-disable-next-line no-console

--- a/src/domains/features/previewSynchronization.ts
+++ b/src/domains/features/previewSynchronization.ts
@@ -27,7 +27,10 @@ export class PreviewSynchronization<T> {
 
   async execute(
     args: T,
-    { format }: { format?: PreviewFormat; output?: string } = {}
+    {
+      format,
+      flat = false,
+    }: { format?: PreviewFormat; output?: string; flat?: boolean } = {}
   ): Promise<string> {
     // Check if the GitHub repository is accessible
     try {
@@ -57,6 +60,10 @@ export class PreviewSynchronization<T> {
     const filePaths = await this.sourceRepository.getFilePathList(args);
 
     const siteMap = SiteMap.buildFromFilePaths(filePaths);
+
+    if (flat) {
+      siteMap.flatten();
+    }
 
     return sitemapSerializer(siteMap);
   }

--- a/src/domains/features/synchronizeMarkdownToNotion_flat.test.ts
+++ b/src/domains/features/synchronizeMarkdownToNotion_flat.test.ts
@@ -1,0 +1,185 @@
+import { FakeFileConverter } from '../../../__tests__/__fakes__/fakeConverter.repository';
+import { FakeDestinationRepository } from '../../../__tests__/__fakes__/fakeDestination.repository';
+import { FakeFile } from '../../../__tests__/__fakes__/fakeFile';
+import { fakeLogger } from '../../../__tests__/__fakes__/fakeLogger';
+import { FakeNotionPage } from '../../../__tests__/__fakes__/fakePage';
+import { FakeSourceRepository } from '../../../__tests__/__fakes__/fakeSource.repository';
+import { PageElement, TextElement } from '../elements';
+import { SynchronizeMarkdownToNotion } from './synchronizeMarkdownToNotion';
+
+describe('SynchronizeMarkdownToNotion - Flat Sync', () => {
+  let synchronizer: SynchronizeMarkdownToNotion<any, any>;
+  let sourceRepository: FakeSourceRepository<FakeFile>;
+  let destinationRepository: FakeDestinationRepository<FakeNotionPage>;
+  let elementConverter: FakeFileConverter;
+
+  const databaseId = 'database-id-12345678901234567890123456789012';
+  const databaseUrl = `https://www.notion.so/workspace/${databaseId}`;
+
+  beforeEach(() => {
+    sourceRepository = new FakeSourceRepository();
+    destinationRepository = new FakeDestinationRepository();
+    elementConverter = new FakeFileConverter({
+      logger: fakeLogger,
+      htmlParser: {} as any,
+      markdownParser: {} as any,
+    });
+
+    synchronizer = new SynchronizeMarkdownToNotion({
+      sourceRepository,
+      destinationRepository,
+      elementConverter,
+      logger: fakeLogger,
+    });
+
+    jest
+      .spyOn(destinationRepository, 'destinationIsAccessible')
+      .mockResolvedValue(true);
+    jest.spyOn(sourceRepository, 'sourceIsAccessible').mockResolvedValue(true);
+    jest
+      .spyOn(destinationRepository, 'getObjectType')
+      .mockResolvedValue('database');
+    jest
+      .spyOn(destinationRepository, 'createPage')
+      .mockResolvedValue(new FakeNotionPage({ pageId: 'new-page-id' }));
+    jest
+      .spyOn(destinationRepository, 'getDataSourceIdFromDatabaseId')
+      .mockResolvedValue('datasource-id');
+    jest
+      .spyOn(destinationRepository, 'deletePagesInDatabaseByInternalId')
+      .mockResolvedValue(undefined);
+  });
+
+  it('should create all files as direct children of the database when flat is true', async () => {
+    // Setup hierarchical file structure
+    jest
+      .spyOn(sourceRepository, 'getFilePathList')
+      .mockResolvedValue([
+        'parent.md',
+        'child/child.md',
+        'child/grandchild/grandchild.md',
+      ]);
+
+    const pageElement = new PageElement({
+      title: 'Test',
+      content: [new TextElement({ text: '# Test' })],
+      mkNotesInternalId: 'test-id',
+    });
+
+    jest
+      .spyOn(sourceRepository, 'getFile')
+      .mockResolvedValue(new FakeFile({ content: '# Test' }));
+    jest
+      .spyOn(elementConverter, 'convertToElement')
+      .mockReturnValue(pageElement);
+
+    const createPageSpy = jest.spyOn(destinationRepository, 'createPage');
+
+    await synchronizer.execute({
+      notionParentPageUrl: databaseUrl,
+      cleanSync: false,
+      lockPage: false,
+      flat: true,
+      path: 'test',
+    });
+
+    // Should create 3 pages
+    expect(createPageSpy).toHaveBeenCalledTimes(3);
+
+    // All pages should be created with parentObjectId = databaseId and parentObjectType = 'database'
+    const calls = createPageSpy.mock.calls;
+
+    for (const call of calls) {
+      expect(call[0]).toMatchObject({
+        parentObjectId: '12345678901234567890123456789012',
+        parentObjectType: 'database',
+      });
+    }
+  });
+
+  it('should respect cleanSync by calling deletePagesInDatabaseByInternalId in flat mode', async () => {
+    jest
+      .spyOn(sourceRepository, 'getFilePathList')
+      .mockResolvedValue(['child.md']);
+
+    const pageElement = new PageElement({
+      title: 'Child',
+      content: [],
+      mkNotesInternalId: 'child-internal-id',
+    });
+
+    jest
+      .spyOn(sourceRepository, 'getFile')
+      .mockResolvedValue(new FakeFile({ content: '' }));
+    jest
+      .spyOn(elementConverter, 'convertToElement')
+      .mockReturnValue(pageElement);
+
+    const deleteSpy = jest.spyOn(
+      destinationRepository,
+      'deletePagesInDatabaseByInternalId'
+    );
+
+    await synchronizer.execute({
+      notionParentPageUrl: databaseUrl,
+      cleanSync: true,
+      lockPage: false,
+      flat: true,
+      path: 'test',
+    });
+
+    expect(deleteSpy).toHaveBeenCalledWith({
+      databaseId: '12345678901234567890123456789012',
+      mkNotesInternalId: 'child-internal-id',
+    });
+  });
+
+  it('should ignore flat option if destination is not a database', async () => {
+    // Mock destination as a page instead of a database
+    jest.spyOn(destinationRepository, 'getObjectType').mockResolvedValue('page');
+    jest
+      .spyOn(destinationRepository, 'appendToPage')
+      .mockResolvedValue(undefined);
+
+    jest
+      .spyOn(sourceRepository, 'getFilePathList')
+      .mockResolvedValue(['parent.md', 'child/child.md']);
+
+    const pageElement = new PageElement({
+      title: 'Test',
+      content: [],
+      mkNotesInternalId: 'id',
+    });
+    jest
+      .spyOn(elementConverter, 'convertToElement')
+      .mockReturnValue(pageElement);
+    jest
+      .spyOn(sourceRepository, 'getFile')
+      .mockResolvedValue(new FakeFile({ content: '' }));
+
+    const createPageSpy = jest.spyOn(destinationRepository, 'createPage');
+
+    await synchronizer.execute({
+      notionParentPageUrl: databaseUrl,
+      cleanSync: false,
+      lockPage: false,
+      flat: true, // Should be ignored
+      path: 'test',
+    });
+
+    // Should behave like hierarchical sync
+    // parent.md -> created as child of root page
+    // child/child.md -> created as child of root page
+    // It will create 2 pages because there is no index.md handling in this fake setup that merges them
+    
+    expect(createPageSpy).toHaveBeenCalledTimes(2);
+    expect(createPageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentObjectType: 'page',
+        // parentObjectId should be the root page ID (databaseId in this mock setup acting as pageId)
+        parentObjectId: '12345678901234567890123456789012',
+      })
+    );
+  });
+});
+

--- a/src/domains/synchronization/destination.repository.ts
+++ b/src/domains/synchronization/destination.repository.ts
@@ -82,4 +82,11 @@ export interface DestinationRepository<T extends Page> {
   }: {
     databaseId: string;
   }) => Promise<string>;
+  deletePagesInDatabaseByInternalId: ({
+    databaseId,
+    mkNotesInternalId,
+  }: {
+    databaseId: string;
+    mkNotesInternalId: string;
+  }) => Promise<void>;
 }

--- a/sync/index.js
+++ b/sync/index.js
@@ -75002,7 +75002,7 @@ class MkNotes {
     /**
      * Preview the synchronization of a markdown file to Notion
      */
-    async previewSynchronization({ inputPath, format, output, }) {
+    async previewSynchronization({ inputPath, format, output, flat = false, }) {
         const previewSynchronizationFeature = new domains_1.PreviewSynchronization({
             sourceRepository: this.infrastructureInstances.fileSystemSource,
         });
@@ -75010,6 +75010,7 @@ class MkNotes {
             path: inputPath,
         }, {
             format,
+            flat,
         });
         if (!output) {
             return result;
@@ -75020,7 +75021,7 @@ class MkNotes {
     /**
      * Synchronize a markdown file to Notion
      */
-    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, }) {
+    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, flat = false, }) {
         const synchronizeMarkdownToNotion = new domains_1.SynchronizeMarkdownToNotion({
             logger: this.logger,
             destinationRepository: this.infrastructureInstances.notionDestination,
@@ -75032,6 +75033,7 @@ class MkNotes {
             notionParentPageUrl: parentNotionPageId,
             cleanSync,
             lockPage,
+            flat,
         });
     }
 }
@@ -75852,7 +75854,7 @@ class PreviewSynchronization {
     constructor(params) {
         this.sourceRepository = params.sourceRepository;
     }
-    async execute(args, { format } = {}) {
+    async execute(args, { format, flat = false, } = {}) {
         // Check if the GitHub repository is accessible
         try {
             await this.sourceRepository.sourceIsAccessible(args);
@@ -75880,6 +75882,9 @@ class PreviewSynchronization {
         }
         const filePaths = await this.sourceRepository.getFilePathList(args);
         const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+        if (flat) {
+            siteMap.flatten();
+        }
         return sitemapSerializer(siteMap);
     }
 }
@@ -75909,7 +75914,7 @@ class SynchronizeMarkdownToNotion {
         this.logger = params.logger;
     }
     async execute(args) {
-        const { notionParentPageUrl, cleanSync, lockPage, ...others } = args;
+        const { notionParentPageUrl, cleanSync, lockPage, flat = false, ...others } = args;
         const notionObjectId = this.destinationRepository.getObjectIdFromObjectUrl({
             objectUrl: notionParentPageUrl,
         });
@@ -75939,6 +75944,9 @@ class SynchronizeMarkdownToNotion {
             this.logger.info('Starting synchronization process');
             const filePaths = await this.sourceRepository.getFilePathList(others);
             const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+            if (flat && parentObjectType === 'database') {
+                siteMap.flatten();
+            }
             // Traverse the SiteMap and synchronize files
             await this.synchronizeTreeNode({
                 node: siteMap.root,
@@ -75946,6 +75954,7 @@ class SynchronizeMarkdownToNotion {
                 parentObjectType,
                 lockPage,
                 cleanSync,
+                flat,
             });
             this.logger.info('Synchronization process completed successfully');
         }
@@ -76035,32 +76044,19 @@ class SynchronizeMarkdownToNotion {
         return newPage.pageId;
     }
     async cleanSyncDatabase({ databaseId, pageElement, }) {
-        const dataSourceId = await this.destinationRepository.getDataSourceIdFromDatabaseId({
-            databaseId,
-        });
         if (pageElement.mkNotesInternalId === undefined) {
             this.logger.warn('mk-notes-internal-id is undefined, skipping clean sync');
             return;
         }
-        const objectIds = await this.destinationRepository.getObjectIdInDatabaseByMkNotesInternalId({
-            dataSourceId,
+        await this.destinationRepository.deletePagesInDatabaseByInternalId({
+            databaseId,
             mkNotesInternalId: pageElement.mkNotesInternalId,
         });
-        if (objectIds.length === 0) {
-            this.logger.warn('No object IDs found, skipping clean sync');
-            return;
-        }
-        if (objectIds.length > 1) {
-            this.logger.info(`Multiple object IDs found with ${pageElement.mkNotesInternalId}, deleting all objects`);
-        }
-        await Promise.all(objectIds.map(async (objectId) => this.destinationRepository.deleteObjectById({
-            objectId,
-        })));
     }
     /**
      * Synchronizes a child node and its descendants recursively
      */
-    async synchronizeChildNode({ childNode, parentPageId, lockPage, }) {
+    async synchronizeChildNode({ childNode, parentPageId, lockPage, cleanSync, parentObjectType = 'page', }) {
         const filePath = childNode.filepath;
         this.logger.info(`Processing file: ${filePath}`);
         const pageElement = await this.fetchAndConvertToPageElement(filePath);
@@ -76070,10 +76066,22 @@ class SynchronizeMarkdownToNotion {
         if (childNode.children.length > 0) {
             pageElement.addElementToEnd(new elements_1.DividerElement());
         }
+        // If parent is a database (e.g. in flat sync), we need to clean up previous version of this specific page
+        if (parentObjectType === 'database' && cleanSync) {
+            if (!pageElement.mkNotesInternalId) {
+                this.logger.warn('mk-notes-internal-id is undefined, skipping clean sync for child node');
+            }
+            else {
+                await this.destinationRepository.deletePagesInDatabaseByInternalId({
+                    databaseId: parentPageId,
+                    mkNotesInternalId: pageElement.mkNotesInternalId,
+                });
+            }
+        }
         const newPage = await this.destinationRepository.createPage({
             pageElement,
             parentObjectId: parentPageId,
-            parentObjectType: 'page',
+            parentObjectType,
             filePath,
         });
         this.logger.info(`Created Notion page for file: ${filePath}`);
@@ -76086,6 +76094,7 @@ class SynchronizeMarkdownToNotion {
                 childNode: grandChild,
                 parentPageId: newPage.pageId,
                 lockPage,
+                cleanSync,
             });
         }
         await this.lockPageIfNeeded(newPage.pageId, lockPage);
@@ -76093,29 +76102,65 @@ class SynchronizeMarkdownToNotion {
     /**
      * Main orchestrator for synchronizing a tree node and its children
      */
-    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, }) {
+    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, flat = false, }) {
         let parentPageId = parentObjectId;
+        if (flat && parentObjectType !== 'database') {
+            this.logger.warn('Flat option ignored because destination is not a database');
+        }
+        const isFlatSync = flat && parentObjectType === 'database';
+        // If flat sync is enabled, flatten the sitemap starting from this node
+        // Since we are passing the root node here usually, this affects the whole tree
+        // But we rely on SiteMap.flatten() which works on the whole structure anyway if we had access to SiteMap
+        // Here we only have the root node. But wait, SiteMap.flatten() modifies the tree structure in place.
+        // Since we don't have the SiteMap instance here, we can implement a helper or just assume
+        // the caller has done it? No, the plan says "If flat is true, call siteMap.flatten() immediately."
+        // But we don't have the siteMap instance here.
+        // Correction: We call synchronizeTreeNode with siteMap.root.
+        // We should probably move the flatten call to `execute` BEFORE calling synchronizeTreeNode.
+        // BUT `execute` has the SiteMap instance!
+        // Let's revert to the plan: "In synchronizeTreeNode: If flat is true, call siteMap.flatten() immediately."
+        // Ah, `synchronizeTreeNode` receives a `node`. It doesn't have the `SiteMap` instance.
+        // The `execute` method has the `SiteMap` instance.
+        // So I will modify `execute` instead to flatten the map.
+        // Wait, I already modified `execute` but didn't add the flatten call there.
+        // I will add the flatten logic in `execute` in a separate tool call.
         switch (parentObjectType) {
             case 'unknown':
                 throw new Error('Parent object type is unknown');
             case 'database':
-                if (this.getIsRootNode(node)) {
-                    parentPageId = await this.synchronizeRootNode({
-                        node,
-                        parentObjectId,
-                        parentObjectType,
-                        lockPage,
-                        cleanSync,
-                    });
+                if (isFlatSync) {
+                    // In flat sync, if the root has content, we sync it to the DB.
+                    if (this.getIsRootNode(node)) {
+                        await this.synchronizeRootNode({
+                            node,
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
+                    // Children will also be synced to the DB (parentObjectId)
+                    parentPageId = parentObjectId;
                 }
                 else {
-                    parentPageId = await this.synchronizeRootNode({
-                        node: node.children[0],
-                        parentObjectId,
-                        parentObjectType,
-                        lockPage,
-                        cleanSync,
-                    });
+                    if (this.getIsRootNode(node)) {
+                        parentPageId = await this.synchronizeRootNode({
+                            node,
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
+                    else {
+                        parentPageId = await this.synchronizeRootNode({
+                            node: node.children[0],
+                            parentObjectId,
+                            parentObjectType,
+                            lockPage,
+                            cleanSync,
+                        });
+                    }
                 }
                 break;
             case 'page':
@@ -76138,6 +76183,8 @@ class SynchronizeMarkdownToNotion {
                     childNode,
                     parentPageId,
                     lockPage,
+                    cleanSync,
+                    parentObjectType: isFlatSync ? 'database' : 'page',
                 });
             }
             catch (error) {
@@ -76522,7 +76569,12 @@ class SiteMap {
     removeUselessNodesTree(node) {
         while (node.children.length === 1 &&
             path.extname(node.children[0].filepath) === '') {
-            node.children = node.children[0].children;
+            const [child] = node.children;
+            node.children = child.children;
+            // Fix parent pointers for the adopted children
+            node.children.forEach((grandChild) => {
+                grandChild.parent = node;
+            });
         }
         return node;
     }
@@ -76532,6 +76584,32 @@ class SiteMap {
     _updateTree() {
         this.removeUselessNodesTree(this._root);
         this.traverseAndUpdate(this._root);
+    }
+    /**
+     * Flattens the sitemap structure so all files are direct children of the root.
+     * This is useful for flat synchronization mode.
+     */
+    flatten() {
+        const allNodes = [];
+        // Collect all nodes except root
+        const collectNodes = (node) => {
+            // We don't include the current node if it's the root
+            if (node !== this._root) {
+                allNodes.push(node);
+            }
+            node.children.forEach(collectNodes);
+        };
+        // Start collection from root's children
+        this._root.children.forEach(collectNodes);
+        // Clear existing children of root
+        this._root.children = [];
+        // Reassign all collected nodes as direct children of root
+        // And clear their children since they are now flat
+        allNodes.forEach((node) => {
+            node.parent = this._root;
+            node.children = [];
+            this._root.children.push(node);
+        });
     }
     /**
      * TODO: Implement mkdocs.yaml sitemap parsing
@@ -79212,6 +79290,25 @@ class NotionDestinationRepository {
             },
         });
         return items.results.map((item) => item.id);
+    }
+    async deletePagesInDatabaseByInternalId({ databaseId, mkNotesInternalId, }) {
+        const dataSourceId = await this.getDataSourceIdFromDatabaseId({
+            databaseId,
+        });
+        const objectIds = await this.getObjectIdInDatabaseByMkNotesInternalId({
+            dataSourceId,
+            mkNotesInternalId,
+        });
+        if (objectIds.length === 0) {
+            this.logger.warn('No object IDs found, skipping clean sync');
+            return;
+        }
+        if (objectIds.length > 1) {
+            this.logger.info(`Multiple object IDs found with ${mkNotesInternalId}, deleting all objects`);
+        }
+        await Promise.all(objectIds.map(async (objectId) => this.deleteObjectById({
+            objectId,
+        })));
     }
     async deleteObjectById({ objectId }) {
         await this.client.blocks.delete({ block_id: objectId });

--- a/sync/index.js
+++ b/sync/index.js
@@ -75940,6 +75940,9 @@ class SynchronizeMarkdownToNotion {
         if (parentObjectType === 'unknown') {
             throw new Error('Parent object type is unknown');
         }
+        if (flat && parentObjectType === 'page') {
+            throw new Error('Flat sync is only supported for database destinations. Pages do not support flat sync.');
+        }
         try {
             this.logger.info('Starting synchronization process');
             const filePaths = await this.sourceRepository.getFilePathList(others);
@@ -76056,7 +76059,7 @@ class SynchronizeMarkdownToNotion {
     /**
      * Synchronizes a child node and its descendants recursively
      */
-    async synchronizeChildNode({ childNode, parentPageId, lockPage, cleanSync, parentObjectType = 'page', }) {
+    async synchronizeChildNode({ childNode, parentObjectId, lockPage, cleanSync, parentObjectType = 'page', }) {
         const filePath = childNode.filepath;
         this.logger.info(`Processing file: ${filePath}`);
         const pageElement = await this.fetchAndConvertToPageElement(filePath);
@@ -76073,14 +76076,14 @@ class SynchronizeMarkdownToNotion {
             }
             else {
                 await this.destinationRepository.deletePagesInDatabaseByInternalId({
-                    databaseId: parentPageId,
+                    databaseId: parentObjectId,
                     mkNotesInternalId: pageElement.mkNotesInternalId,
                 });
             }
         }
         const newPage = await this.destinationRepository.createPage({
             pageElement,
-            parentObjectId: parentPageId,
+            parentObjectId,
             parentObjectType,
             filePath,
         });
@@ -76092,7 +76095,7 @@ class SynchronizeMarkdownToNotion {
         for (const grandChild of childNode.children) {
             await this.synchronizeChildNode({
                 childNode: grandChild,
-                parentPageId: newPage.pageId,
+                parentObjectId: newPage.pageId,
                 lockPage,
                 cleanSync,
             });
@@ -76104,64 +76107,19 @@ class SynchronizeMarkdownToNotion {
      */
     async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, flat = false, }) {
         let parentPageId = parentObjectId;
-        if (flat && parentObjectType !== 'database') {
-            this.logger.warn('Flat option ignored because destination is not a database');
-        }
         const isFlatSync = flat && parentObjectType === 'database';
-        // If flat sync is enabled, flatten the sitemap starting from this node
-        // Since we are passing the root node here usually, this affects the whole tree
-        // But we rely on SiteMap.flatten() which works on the whole structure anyway if we had access to SiteMap
-        // Here we only have the root node. But wait, SiteMap.flatten() modifies the tree structure in place.
-        // Since we don't have the SiteMap instance here, we can implement a helper or just assume
-        // the caller has done it? No, the plan says "If flat is true, call siteMap.flatten() immediately."
-        // But we don't have the siteMap instance here.
-        // Correction: We call synchronizeTreeNode with siteMap.root.
-        // We should probably move the flatten call to `execute` BEFORE calling synchronizeTreeNode.
-        // BUT `execute` has the SiteMap instance!
-        // Let's revert to the plan: "In synchronizeTreeNode: If flat is true, call siteMap.flatten() immediately."
-        // Ah, `synchronizeTreeNode` receives a `node`. It doesn't have the `SiteMap` instance.
-        // The `execute` method has the `SiteMap` instance.
-        // So I will modify `execute` instead to flatten the map.
-        // Wait, I already modified `execute` but didn't add the flatten call there.
-        // I will add the flatten logic in `execute` in a separate tool call.
         switch (parentObjectType) {
             case 'unknown':
                 throw new Error('Parent object type is unknown');
             case 'database':
-                if (isFlatSync) {
-                    // In flat sync, if the root has content, we sync it to the DB.
-                    if (this.getIsRootNode(node)) {
-                        await this.synchronizeRootNode({
-                            node,
-                            parentObjectId,
-                            parentObjectType,
-                            lockPage,
-                            cleanSync,
-                        });
-                    }
-                    // Children will also be synced to the DB (parentObjectId)
-                    parentPageId = parentObjectId;
-                }
-                else {
-                    if (this.getIsRootNode(node)) {
-                        parentPageId = await this.synchronizeRootNode({
-                            node,
-                            parentObjectId,
-                            parentObjectType,
-                            lockPage,
-                            cleanSync,
-                        });
-                    }
-                    else {
-                        parentPageId = await this.synchronizeRootNode({
-                            node: node.children[0],
-                            parentObjectId,
-                            parentObjectType,
-                            lockPage,
-                            cleanSync,
-                        });
-                    }
-                }
+                parentPageId = await this.handleDatabaseSynchronization({
+                    node,
+                    parentObjectId,
+                    parentObjectType,
+                    lockPage,
+                    cleanSync,
+                    isFlatSync,
+                });
                 break;
             case 'page':
                 if (this.getIsRootNode(node)) {
@@ -76181,7 +76139,7 @@ class SynchronizeMarkdownToNotion {
             try {
                 await this.synchronizeChildNode({
                     childNode,
-                    parentPageId,
+                    parentObjectId: parentPageId,
                     lockPage,
                     cleanSync,
                     parentObjectType: isFlatSync ? 'database' : 'page',
@@ -76194,6 +76152,36 @@ class SynchronizeMarkdownToNotion {
                 throw error;
             }
         }
+    }
+    async handleDatabaseSynchronization({ node, parentObjectId, parentObjectType, lockPage, cleanSync, isFlatSync, }) {
+        if (isFlatSync) {
+            if (this.getIsRootNode(node)) {
+                await this.synchronizeRootNode({
+                    node,
+                    parentObjectId,
+                    parentObjectType,
+                    lockPage,
+                    cleanSync,
+                });
+            }
+            return parentObjectId;
+        }
+        if (this.getIsRootNode(node)) {
+            return await this.synchronizeRootNode({
+                node,
+                parentObjectId,
+                parentObjectType,
+                lockPage,
+                cleanSync,
+            });
+        }
+        return await this.synchronizeRootNode({
+            node: node.children[0],
+            parentObjectId,
+            parentObjectType,
+            lockPage,
+            cleanSync,
+        });
     }
     getIsRootNode(node) {
         return node.parent === null && !['', undefined].includes(node.filepath);


### PR DESCRIPTION
Added --flat parameter for database syncs, preventing nesting of pages. This is useful if you have a larger set of MD files in a folder but want to have all of them as single entries in your database instead of nested child pages. So you can filter through all the documents e.g. via their properties. 

-----
All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully run tests with your changes locally?