### PR TITLE
feat(#70): add option to flat page tree inside a destination

### DIFF
--- a/docs/content/docs/cli/guides/cli-commands.mdx
+++ b/docs/content/docs/cli/guides/cli-commands.mdx
@@ -62,6 +62,18 @@ mk-notes sync -i <path> -d <notionUrl> -k <notionApiKey>
 
   </Callout>
 
+- `--flat`: Flatten the result page tree, making all pages direct children of the destination instead of maintaining nested folder structures. When enabled, the root node is skipped and all files are created as direct children of the parent page.
+
+  <Callout type="info" title="When to use flat mode">
+
+  Use `--flat` when you want a flat list of pages in Notion rather than a hierarchical structure. This is useful for:
+
+  - Creating a simple list of documents without nested folders
+  - Syncing to databases where you want all items at the same level
+  - Simplifying navigation when folder structure isn't important
+
+  </Callout>
+
 ### Destination Types
 
 Mk Notes supports two types of destinations:
@@ -274,6 +286,46 @@ This command will:
 
 This is useful when you want to completely reset your synchronization and start fresh with new page IDs.
 
+#### Syncing with Flat Structure
+
+```bash
+mk-notes sync \
+  --input ./my-docs \
+  --destination https://notion.so/myworkspace/doc-123456 \
+  --notion-api-key secret_abc123... \
+  --flat
+```
+
+This command will:
+
+1. Read all markdown files in the `./my-docs` directory
+2. **Flatten the structure** - all pages will be created as direct children of the destination page
+3. Skip synchronizing the root node (if your directory has an `index.md`, it will be created as a child page instead of updating the parent)
+4. Display a success message with the Notion page URL when complete
+
+**Example structure:**
+
+Without `--flat`:
+
+```
+Parent Page
+  └── docs/
+      ├── getting-started.md
+      └── guides/
+          └── installation.md
+```
+
+With `--flat`:
+
+```
+Parent Page
+  ├── docs/ (root copy)
+  ├── getting-started.md
+  └── installation.md
+```
+
+All files are now direct children, making navigation simpler.
+
 ## `preview-sync`
 
 The `preview-sync` command lets you preview how your markdown files will be organized in Notion before actually performing the synchronization. This is useful for verifying the structure before making any changes.
@@ -294,6 +346,7 @@ mk-notes preview-sync -i <path> [options]
   - `plainText` (default): Shows a tree-like structure
   - `json`: Outputs the structure in JSON format
 - `-o, --output <output>`: Save the preview to a file instead of displaying it in the terminal
+- `--flat`: Flatten the preview structure, showing how pages will appear when using the `--flat` option in sync. All pages will be displayed as direct children of the root.
 
 ### Examples
 
@@ -340,6 +393,14 @@ mk-notes preview-sync --input ./my-docs --output preview.txt
 ```bash
 mk-notes preview-sync --input ./my-docs/README.md
 ```
+
+5. Preview with flat structure:
+
+```bash
+mk-notes preview-sync --input ./my-docs --flat
+```
+
+This shows how the structure will look when using `--flat` during sync, with all pages as direct children of the root.
 
 ---
 

--- a/docs/content/docs/cli/guides/database-sync.mdx
+++ b/docs/content/docs/cli/guides/database-sync.mdx
@@ -148,6 +148,31 @@ mk-notes sync -i ./docs -d <database-url> -k <api-key> --clean --force-new
 
 </Callout>
 
+### Flat Structure
+
+The `--flat` option flattens the page tree, making all pages direct children of the database instead of maintaining nested folder structures:
+
+```bash
+mk-notes sync \
+  --input ./docs \
+  --destination https://notion.so/myworkspace/database-123456 \
+  --notion-api-key secret_abc123... \
+  --flat
+```
+
+When syncing to databases, `--flat` is particularly useful because:
+
+- All pages appear at the same level in the database
+- Easier to filter and sort all documents uniformly
+- No nested hierarchy to navigate
+- Better for database views where you want all items visible at once
+
+<Callout type="info" title="Database sync with flat">
+
+When using `--flat` with database sync, the root node is skipped and all files become direct database items. This creates a clean, flat list of all your documents in the database, making them easier to manage with database views and filters.
+
+</Callout>
+
 ### Combining Options
 
 You can combine `--save-id` and `--force-new` with `--clean` for different workflows:
@@ -156,8 +181,10 @@ You can combine `--save-id` and `--force-new` with `--clean` for different workf
 | ------------------------------- | ---------------------------------------------------------- |
 | `--save-id`                     | Updates existing pages by ID, saves new IDs to frontmatter |
 | `--force-new`                   | Creates new pages, ignores existing IDs                    |
+| `--flat`                        | Flattens structure, all pages become direct children       |
 | `--clean --save-id`             | Deletes old pages, creates new ones, saves new IDs         |
 | `--clean --force-new --save-id` | Full reset: deletes all, creates new pages, saves new IDs  |
+| `--flat --save-id`              | Flat structure with incremental updates                    |
 
 ---
 

--- a/docs/content/docs/github-actions/available-actions/2-sync-action.mdx
+++ b/docs/content/docs/github-actions/available-actions/2-sync-action.mdx
@@ -31,15 +31,16 @@ steps:
 
 ## Inputs
 
-| Input            | Description                                                                                                           | Required | Default |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `input`          | The path to the markdown file or directory to synchronize                                                             | `true`   | -       |
-| `destination`    | The Notion page or database URL where you want to synchronize your markdown files                                     | `true`   | -       |
-| `notion-api-key` | Your Notion secret token                                                                                              | `true`   | -       |
-| `clean`          | Clean sync mode - removes ALL existing content from the destination before syncing                                    | `false`  | `false` |
-| `lock`           | Lock the Notion page after syncing                                                                                    | `false`  | `false` |
-| `save-id`        | Save Notion page IDs back to the source markdown files' frontmatter, enabling incremental updates on subsequent syncs | `false`  | `false` |
-| `force-new`      | Force creation of new pages, ignoring any existing page IDs in the markdown frontmatter                               | `false`  | `false` |
+| Input            | Description                                                                                                                | Required | Default |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `input`          | The path to the markdown file or directory to synchronize                                                                  | `true`   | -       |
+| `destination`    | The Notion page or database URL where you want to synchronize your markdown files                                          | `true`   | -       |
+| `notion-api-key` | Your Notion secret token                                                                                                   | `true`   | -       |
+| `clean`          | Clean sync mode - removes ALL existing content from the destination before syncing                                         | `false`  | `false` |
+| `lock`           | Lock the Notion page after syncing                                                                                         | `false`  | `false` |
+| `save-id`        | Save Notion page IDs back to the source markdown files' frontmatter, enabling incremental updates on subsequent syncs      | `false`  | `false` |
+| `force-new`      | Force creation of new pages, ignoring any existing page IDs in the markdown frontmatter                                    | `false`  | `false` |
+| `flat`           | Flatten the result page tree, making all pages direct children of the destination instead of maintaining nested structures | `false`  | `false` |
 
 ## Destination Types
 
@@ -294,11 +295,47 @@ jobs:
           git push
 ```
 
+### Sync with Flat Structure
+
+Use `flat` to create a flat list of pages instead of maintaining nested folder structures:
+
+```yaml
+name: Flat Sync
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+
+jobs:
+  flat-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync with flat structure
+        uses: Myastr0/mk-notes/sync
+        with:
+          input: './docs'
+          destination: ${{ secrets.NOTION_DOCS_PAGE_URL }}
+          notion-api-key: ${{ secrets.NOTION_API_KEY }}
+          flat: 'true'
+```
+
+When `flat: 'true'` is used:
+
+- All pages are created as direct children of the destination page
+- The root node is skipped (if your directory has an `index.md`, it becomes a child page)
+- Folder hierarchy is flattened into a simple list
+- Useful for creating simple document lists or syncing to databases where you want all items at the same level
+
 ## Important Notes
 
 - **For clean sync**: The `clean` option removes ALL existing content from the destination before syncing
 - **For save-id**: Remember to commit the updated markdown files back to your repository
 - **For force-new**: Use with caution as it may create duplicate pages if used without `clean`
+- **For flat**: When using `flat`, the root node is skipped and all files become direct children. This is ideal for simple document lists or database syncs where hierarchy isn't needed
 - Use clean sync only when you're sure you want to replace content
 - Always test with the [preview action](./1-preview-action.mdx) first
 - Make sure your Notion integration has access to the target page or database

--- a/src/MkNotes.test.ts
+++ b/src/MkNotes.test.ts
@@ -58,6 +58,18 @@ describe('MkNotes', () => {
 
       expect(writeFileSpy).toHaveBeenCalledWith(outputPath, expect.any(String));
     });
+
+    it('should support flatten option', async () => {
+      const result = await mkNotes.previewSynchronization({
+        inputPath: 'fake/input/path.md',
+        format: 'json',
+        flatten: true,
+      });
+
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      expect(JSON.parse(result)).toEqual(expect.any(Object));
+    });
   });
 
   describe('synchronizeMarkdownToNotionFromFileSystem', () => {
@@ -77,10 +89,34 @@ describe('MkNotes', () => {
         lockPage: false,
         saveId: false,
         forceNew: false,
+        flatten: false,
       });
 
       // Without cleanSync, the root file updates the parent page
       expect(updatePageSpy).toHaveBeenCalled();
+    });
+
+    it('should support flatten option', async () => {
+      const updatePageSpy = jest.spyOn(
+        infrastructureInstances.notionDestination,
+        'updatePage'
+      );
+
+      const notionPageUrl =
+        'https://www.notion.so/workspace/Test-Page-12345678901234567890123456789012';
+
+      await mkNotes.synchronizeMarkdownToNotionFromFileSystem({
+        inputPath: 'fake/input/path.md',
+        parentNotionPageId: notionPageUrl,
+        cleanSync: false,
+        lockPage: false,
+        saveId: false,
+        forceNew: false,
+        flatten: true,
+      });
+
+      // With flatten, root node is skipped, so updatePage should not be called
+      expect(updatePageSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/MkNotes.ts
+++ b/src/MkNotes.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import winston from 'winston';
 
 import {
-  PreviewFormat,
   PreviewSynchronization,
+  PreviewSynchronizationOptions,
   SynchronizeMarkdownToNotion,
   SynchronizeOptions,
 } from '@/domains';
@@ -13,12 +13,6 @@ import {
 } from '@/infrastructure';
 
 import { LogLevel } from './domains/logger/types';
-
-export interface SyncOptions {
-  cleanSync: boolean;
-  lockPage: boolean;
-  saveId: boolean;
-}
 
 /**
  * MkNotes client
@@ -57,9 +51,8 @@ export class MkNotes {
     output,
   }: {
     inputPath: string;
-    format: PreviewFormat;
     output?: string;
-  }): Promise<string> {
+  } & PreviewSynchronizationOptions): Promise<string> {
     const previewSynchronizationFeature = new PreviewSynchronization({
       sourceRepository: this.infrastructureInstances.fileSystemSource,
     });
@@ -92,6 +85,7 @@ export class MkNotes {
     lockPage = false,
     saveId = false,
     forceNew = false,
+    flatten = false,
   }: {
     inputPath: string;
     parentNotionPageId: string;
@@ -110,6 +104,7 @@ export class MkNotes {
       lockPage,
       saveId,
       forceNew,
+      flatten,
     });
   }
 }

--- a/src/bin/cli/commands/preview.ts
+++ b/src/bin/cli/commands/preview.ts
@@ -51,6 +51,8 @@ command.addOption(
     .default('plainText')
 );
 
+command.option('--flat', 'Flatten the result page tree');
+
 command.option('-o, --output <output>', 'Output file path');
 
 command.option('-v, --verbosity <verbosity>', 'Verbosity level', 'error');
@@ -60,9 +62,16 @@ interface PreviewOptions {
   format: PreviewFormat;
   output?: string;
   verbosity?: string;
+  flat?: boolean;
 }
 command.action(async (opts: PreviewOptions) => {
-  const { input: directoryPath, format, output, verbosity = 'error' } = opts;
+  const {
+    input: directoryPath,
+    format,
+    output,
+    flat = false,
+    verbosity = 'error',
+  } = opts;
 
   if (!isValidVerbosity(verbosity)) {
     throw new Error(`Invalid verbosity: ${verbosity}`);
@@ -77,6 +86,7 @@ command.action(async (opts: PreviewOptions) => {
     inputPath: directoryPath,
     format,
     output,
+    flatten: flat,
   });
 
   // eslint-disable-next-line no-console

--- a/src/bin/cli/commands/sync.ts
+++ b/src/bin/cli/commands/sync.ts
@@ -38,6 +38,8 @@ command.option('-s, --save-id', 'Save the page ID to the source repository');
 
 command.option('-f, --force-new', 'Force a new page to be created');
 
+command.option('--flat', 'Flatten the result page tree');
+
 command.option('-v, --verbosity <verbosity>', 'Verbosity level', 'error');
 interface SyncOptions {
   input: string;
@@ -48,6 +50,7 @@ interface SyncOptions {
   saveId?: boolean;
   verbosity?: string;
   forceNew?: boolean;
+  flat?: boolean;
 }
 
 command.action(async (opts: SyncOptions) => {
@@ -60,6 +63,7 @@ command.action(async (opts: SyncOptions) => {
     saveId = false,
     forceNew = false,
     verbosity = 'error',
+    flat = false,
   } = opts;
 
   if (!isValidVerbosity(verbosity)) {
@@ -78,6 +82,7 @@ command.action(async (opts: SyncOptions) => {
     lockPage: lock,
     saveId: saveId,
     forceNew: forceNew,
+    flatten: flat,
   });
 
   // eslint-disable-next-line no-console

--- a/src/bin/github-actions/sync.ts
+++ b/src/bin/github-actions/sync.ts
@@ -12,6 +12,7 @@ enum Inputs {
   Lock = 'lock', // Lock page
   SaveId = 'save-id', // Save ID
   ForceNew = 'force-new', // Force new
+  Flat = 'flat', // Flatten the result page tree
 }
 
 export const sync = async (earlyExit: boolean = false) => {
@@ -23,7 +24,7 @@ export const sync = async (earlyExit: boolean = false) => {
     const lock = getInputAsBool(Inputs.Lock) ?? false;
     const saveId = getInputAsBool(Inputs.SaveId);
     const forceNew = getInputAsBool(Inputs.ForceNew);
-
+    const flat = getInputAsBool(Inputs.Flat);
     const mkNotes = new MkNotes({
       notionApiKey,
     });
@@ -35,6 +36,7 @@ export const sync = async (earlyExit: boolean = false) => {
       lockPage: lock,
       saveId: saveId,
       forceNew: forceNew,
+      flatten: flat,
     });
 
     // node will stay alive if any promises are not resolved,

--- a/src/domains/sitemap/entities/SiteMap.ts
+++ b/src/domains/sitemap/entities/SiteMap.ts
@@ -147,6 +147,34 @@ export class SiteMap {
   }
 
   /**
+   * Returns a new SiteMap instance with the tree flattened under the root node
+   */
+  public flatten(): SiteMap {
+    const flattenedSiteMap = new SiteMap();
+    const flattenedChildren = this._root.flatten();
+
+    // Create a copy of the original root node WITHOUT its children
+    // (just the root node itself, not its nested structure)
+    const rootCopy = new TreeNode({
+      id: this._root.id,
+      name: this._root.name,
+      filepath: this._root.filepath,
+      children: [],
+      parent: flattenedSiteMap._root,
+    });
+
+    // Create deep copies of all flattened children and set their parent to the new root
+    const flattenedChildrenCopies = flattenedChildren.map((child) =>
+      TreeNode.fromJSON(child.toJSON(), flattenedSiteMap._root)
+    );
+
+    // Set children: original root copy (without nested children) first, then all flattened descendants copies
+    flattenedSiteMap._root.children = [rootCopy, ...flattenedChildrenCopies];
+
+    return flattenedSiteMap;
+  }
+
+  /**
    * TODO: Implement mkdocs.yaml sitemap parsing
    *
    * Parses the mkdocs.yaml content and adds nodes to the sitemap

--- a/src/domains/sitemap/entities/TreeNode.ts
+++ b/src/domains/sitemap/entities/TreeNode.ts
@@ -57,4 +57,21 @@ export class TreeNode {
 
     return node;
   }
+
+  public flatten(): TreeNode[] {
+    // Recursively flatten all children
+    const flattenedChildren = this.children.reduce(
+      (acc, child) => acc.concat(child.flatten()),
+      [] as TreeNode[]
+    );
+
+    // If the node is the root node, return only the flattened children
+    // (the root itself is not included as it's already in the SiteMap)
+    if (this.parent === null) {
+      return flattenedChildren;
+    }
+
+    // For non-root nodes, include this node followed by its flattened children
+    return [this, ...flattenedChildren];
+  }
 }

--- a/src/domains/sitemap/entities/__tests__/TreeNode.test.ts
+++ b/src/domains/sitemap/entities/__tests__/TreeNode.test.ts
@@ -144,4 +144,158 @@ describe('TreeNode', () => {
       expect(root.parent).toBeNull();
     });
   });
+
+  describe('flatten', () => {
+    it('should return empty array for root node with no children', () => {
+      const root = new TreeNode({
+        id: 'root',
+        name: 'root',
+        filepath: '',
+        parent: null,
+      });
+
+      const flattened = root.flatten();
+
+      expect(flattened).toEqual([]);
+    });
+
+    it('should return only children for root node (not the root itself)', () => {
+      const child1 = new TreeNode({
+        id: 'child1',
+        name: 'Child 1',
+        filepath: '/child1.md',
+      });
+
+      const child2 = new TreeNode({
+        id: 'child2',
+        name: 'Child 2',
+        filepath: '/child2.md',
+      });
+
+      const root = new TreeNode({
+        id: 'root',
+        name: 'root',
+        filepath: '',
+        parent: null,
+        children: [child1, child2],
+      });
+
+      const flattened = root.flatten();
+
+      expect(flattened).toHaveLength(2);
+      expect(flattened[0]).toBe(child1);
+      expect(flattened[1]).toBe(child2);
+      expect(flattened).not.toContain(root);
+    });
+
+    it('should return node itself plus flattened children for non-root node', () => {
+      const grandchild = new TreeNode({
+        id: 'grandchild',
+        name: 'Grandchild',
+        filepath: '/parent/child/grandchild.md',
+      });
+
+      const child = new TreeNode({
+        id: 'child',
+        name: 'Child',
+        filepath: '/parent/child.md',
+        children: [grandchild],
+      });
+
+      const parent = new TreeNode({
+        id: 'parent',
+        name: 'Parent',
+        filepath: '/parent.md',
+        children: [child],
+      });
+
+      // Set up a root node
+      const root = new TreeNode({
+        id: 'root',
+        name: 'root',
+        filepath: '',
+        parent: null,
+        children: [parent],
+      });
+
+      const flattened = child.flatten();
+
+      expect(flattened).toHaveLength(2);
+      expect(flattened[0]).toBe(child);
+      expect(flattened[1]).toBe(grandchild);
+    });
+
+    it('should recursively flatten nested children', () => {
+      const level3 = new TreeNode({
+        id: 'level3',
+        name: 'Level 3',
+        filepath: '/level1/level2/level3.md',
+      });
+
+      const level2 = new TreeNode({
+        id: 'level2',
+        name: 'Level 2',
+        filepath: '/level1/level2.md',
+        children: [level3],
+      });
+
+      const level1 = new TreeNode({
+        id: 'level1',
+        name: 'Level 1',
+        filepath: '/level1.md',
+        children: [level2],
+      });
+
+      const root = new TreeNode({
+        id: 'root',
+        name: 'root',
+        filepath: '',
+        parent: null,
+        children: [level1],
+      });
+
+      const flattened = level1.flatten();
+
+      expect(flattened).toHaveLength(3);
+      expect(flattened[0]).toBe(level1);
+      expect(flattened[1]).toBe(level2);
+      expect(flattened[2]).toBe(level3);
+    });
+
+    it('should handle multiple children at the same level', () => {
+      const child1 = new TreeNode({
+        id: 'child1',
+        name: 'Child 1',
+        filepath: '/parent/child1.md',
+      });
+
+      const child2 = new TreeNode({
+        id: 'child2',
+        name: 'Child 2',
+        filepath: '/parent/child2.md',
+      });
+
+      const parent = new TreeNode({
+        id: 'parent',
+        name: 'Parent',
+        filepath: '/parent.md',
+        children: [child1, child2],
+      });
+
+      const root = new TreeNode({
+        id: 'root',
+        name: 'root',
+        filepath: '',
+        parent: null,
+        children: [parent],
+      });
+
+      const flattened = parent.flatten();
+
+      expect(flattened).toHaveLength(3);
+      expect(flattened[0]).toBe(parent);
+      expect(flattened[1]).toBe(child1);
+      expect(flattened[2]).toBe(child2);
+    });
+  });
 }); 

--- a/src/domains/synchronization/features/preview-synchronization.feature.ts
+++ b/src/domains/synchronization/features/preview-synchronization.feature.ts
@@ -18,6 +18,14 @@ export const isValidFormat = (format: unknown): format is PreviewFormat => {
   );
 };
 
+export interface PreviewSynchronizationOptions {
+  /** The format of the preview */
+  format?: PreviewFormat;
+
+  /** When true, flatten the result page tree */
+  flatten?: boolean;
+}
+
 export class PreviewSynchronization<T> {
   private sourceRepository: SourceRepository<T>;
 
@@ -27,7 +35,7 @@ export class PreviewSynchronization<T> {
 
   async execute(
     args: T,
-    { format }: { format?: PreviewFormat; output?: string } = {}
+    { format, flatten }: PreviewSynchronizationOptions = {}
   ): Promise<string> {
     // Check if the source repository is accessible
     try {
@@ -56,7 +64,11 @@ export class PreviewSynchronization<T> {
 
     const filePaths = await this.sourceRepository.getFilePathList(args);
 
-    const siteMap = SiteMap.buildFromFilePaths(filePaths);
+    let siteMap = SiteMap.buildFromFilePaths(filePaths);
+
+    if (flatten) {
+      siteMap = siteMap.flatten();
+    }
 
     return sitemapSerializer(siteMap);
   }

--- a/sync/index.js
+++ b/sync/index.js
@@ -75020,7 +75020,7 @@ class MkNotes {
     /**
      * Synchronize a markdown file to Notion
      */
-    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, saveId = false, forceNew = false, }) {
+    async synchronizeMarkdownToNotionFromFileSystem({ inputPath, parentNotionPageId, cleanSync = false, lockPage = false, saveId = false, forceNew = false, flatten = false, }) {
         const synchronizeMarkdownToNotion = new domains_1.SynchronizeMarkdownToNotion({
             logger: this.logger,
             destinationRepository: this.infrastructureInstances.notionDestination,
@@ -75034,6 +75034,7 @@ class MkNotes {
             lockPage,
             saveId,
             forceNew,
+            flatten,
         });
     }
 }
@@ -75061,6 +75062,7 @@ var Inputs;
     Inputs["Lock"] = "lock";
     Inputs["SaveId"] = "save-id";
     Inputs["ForceNew"] = "force-new";
+    Inputs["Flat"] = "flat";
 })(Inputs || (Inputs = {}));
 const sync = async (earlyExit = false) => {
     try {
@@ -75071,6 +75073,7 @@ const sync = async (earlyExit = false) => {
         const lock = (0, utils_1.getInputAsBool)(Inputs.Lock) ?? false;
         const saveId = (0, utils_1.getInputAsBool)(Inputs.SaveId);
         const forceNew = (0, utils_1.getInputAsBool)(Inputs.ForceNew);
+        const flat = (0, utils_1.getInputAsBool)(Inputs.Flat);
         const mkNotes = new MkNotes_1.MkNotes({
             notionApiKey,
         });
@@ -75081,6 +75084,7 @@ const sync = async (earlyExit = false) => {
             lockPage: lock,
             saveId: saveId,
             forceNew: forceNew,
+            flatten: flat,
         });
         // node will stay alive if any promises are not resolved,
         // which is a possibility if HTTP requests are dangling
@@ -76184,6 +76188,27 @@ class SiteMap {
         this.traverseAndUpdate(this._root);
     }
     /**
+     * Returns a new SiteMap instance with the tree flattened under the root node
+     */
+    flatten() {
+        const flattenedSiteMap = new SiteMap();
+        const flattenedChildren = this._root.flatten();
+        // Create a copy of the original root node WITHOUT its children
+        // (just the root node itself, not its nested structure)
+        const rootCopy = new TreeNode_1.TreeNode({
+            id: this._root.id,
+            name: this._root.name,
+            filepath: this._root.filepath,
+            children: [],
+            parent: flattenedSiteMap._root,
+        });
+        // Create deep copies of all flattened children and set their parent to the new root
+        const flattenedChildrenCopies = flattenedChildren.map((child) => TreeNode_1.TreeNode.fromJSON(child.toJSON(), flattenedSiteMap._root));
+        // Set children: original root copy (without nested children) first, then all flattened descendants copies
+        flattenedSiteMap._root.children = [rootCopy, ...flattenedChildrenCopies];
+        return flattenedSiteMap;
+    }
+    /**
      * TODO: Implement mkdocs.yaml sitemap parsing
      *
      * Parses the mkdocs.yaml content and adds nodes to the sitemap
@@ -76261,6 +76286,17 @@ class TreeNode {
         // Recursively create children and set their parent
         node.children = json.children.map((child) => this.fromJSON(child, node));
         return node;
+    }
+    flatten() {
+        // Recursively flatten all children
+        const flattenedChildren = this.children.reduce((acc, child) => acc.concat(child.flatten()), []);
+        // If the node is the root node, return only the flattened children
+        // (the root itself is not included as it's already in the SiteMap)
+        if (this.parent === null) {
+            return flattenedChildren;
+        }
+        // For non-root nodes, include this node followed by its flattened children
+        return [this, ...flattenedChildren];
     }
 }
 exports.TreeNode = TreeNode;
@@ -76425,7 +76461,7 @@ class PreviewSynchronization {
     constructor(params) {
         this.sourceRepository = params.sourceRepository;
     }
-    async execute(args, { format } = {}) {
+    async execute(args, { format, flatten } = {}) {
         // Check if the source repository is accessible
         try {
             await this.sourceRepository.sourceIsAccessible(args);
@@ -76452,7 +76488,10 @@ class PreviewSynchronization {
             }
         }
         const filePaths = await this.sourceRepository.getFilePathList(args);
-        const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+        let siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+        if (flatten) {
+            siteMap = siteMap.flatten();
+        }
         return sitemapSerializer(siteMap);
     }
 }
@@ -76482,7 +76521,7 @@ class SynchronizeMarkdownToNotion {
         this.logger = params.logger;
     }
     async execute(args) {
-        const { notionParentPageUrl, cleanSync, lockPage, saveId, forceNew, ...others } = args;
+        const { notionParentPageUrl, cleanSync, lockPage, saveId, forceNew, flatten, ...others } = args;
         const notionObjectId = this.destinationRepository.getObjectIdFromObjectUrl({
             objectUrl: notionParentPageUrl,
         });
@@ -76511,7 +76550,10 @@ class SynchronizeMarkdownToNotion {
         try {
             this.logger.info('Starting synchronization process');
             const filePaths = await this.sourceRepository.getFilePathList(others);
-            const siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+            let siteMap = sitemap_1.SiteMap.buildFromFilePaths(filePaths);
+            if (flatten) {
+                siteMap = siteMap.flatten();
+            }
             // Traverse the SiteMap and synchronize files
             const pages = await this.synchronizeTreeNode({
                 node: siteMap.root,
@@ -76520,6 +76562,7 @@ class SynchronizeMarkdownToNotion {
                 lockPage,
                 cleanSync,
                 forceNew,
+                flatten,
             });
             this.logger.info('Synchronization process completed successfully');
             if (saveId) {
@@ -76580,24 +76623,29 @@ class SynchronizeMarkdownToNotion {
     /**
      * Main orchestrator for synchronizing a tree node and its children
      */
-    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, forceNew, }) {
+    async synchronizeTreeNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, forceNew, flatten, }) {
         this.validateParentObjectType(parentObjectType);
         const nodeToSync = this.getNodeToSynchronize(node, parentObjectType);
         const results = [];
-        const { page: rootPageElement, treeNodeId: rootTreeNodeId } = await this.synchronizeRootNode({
-            node: nodeToSync,
-            parentObjectId,
-            parentObjectType,
-            lockPage,
-            cleanSync,
-            forceNew,
-        });
-        results.push({ page: rootPageElement, treeNodeId: rootTreeNodeId });
+        let rootPageElement;
+        // If not flattening, synchronize the root node
+        if (!flatten) {
+            const { page: rootPageElement, treeNodeId: rootTreeNodeId } = await this.synchronizeRootNode({
+                node: nodeToSync,
+                parentObjectId,
+                parentObjectType,
+                lockPage,
+                cleanSync,
+                forceNew,
+                flatten,
+            });
+            results.push({ page: rootPageElement, treeNodeId: rootTreeNodeId });
+        }
         for (const childNode of node.children) {
             try {
                 const childResults = await this.synchronizeChildNode({
                     childNode,
-                    parentPageId: rootPageElement.id,
+                    parentPageId: rootPageElement?.id ?? parentObjectId,
                     lockPage,
                     forceNew,
                 });
@@ -76616,7 +76664,7 @@ class SynchronizeMarkdownToNotion {
      * Synchronizes the root node to the parent object (page or database)
      * Returns the page ID to use as parent for child nodes
      */
-    async synchronizeRootNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, forceNew, }) {
+    async synchronizeRootNode({ node, parentObjectId, parentObjectType, lockPage, cleanSync, forceNew, flatten, }) {
         this.logger.info(`Adding content from ${node.filepath} to parent ${parentObjectType}`);
         const pageElement = await this.fetchAndConvertToPageElement(node.filepath, {
             forceNew,
@@ -76636,39 +76684,63 @@ class SynchronizeMarkdownToNotion {
                 };
             }
         }
-        if (parentObjectType === 'unknown') {
-            throw new Error('Parent object type is unknown');
-        }
-        if (parentObjectType === 'page') {
-            // If clean sync is enabled, delete all existing content first
-            if (cleanSync) {
-                this.logger.info('Clean sync enabled - removing existing content');
-                try {
-                    await this.destinationRepository.deleteChildBlocks({
-                        parentPageId: parentObjectId,
-                    });
-                    this.logger.info('Successfully removed existing content');
-                }
-                catch (error) {
-                    this.logger.warn('Failed to remove existing content, continuing with sync', { error });
-                }
-                const newPage = await this.destinationRepository.createPage({
-                    pageElement,
+        switch (parentObjectType) {
+            case 'page':
+                return await this.synchronizeRootNodeWithParentPage({
+                    node,
                     parentObjectId,
                     parentObjectType,
+                    pageElement,
+                    lockPage,
+                    cleanSync,
+                    flatten,
                 });
-                pageElement.id = newPage.pageId;
-                return { page: pageElement, treeNodeId: node.id };
+            case 'database':
+                return await this.synchronizeRootNodeWithParentDatabase({
+                    node,
+                    parentObjectId,
+                    parentObjectType,
+                    pageElement,
+                    cleanSync,
+                });
+            case 'unknown':
+            default:
+                throw new Error(`Invalid parent object type: ${parentObjectType}`);
+        }
+    }
+    async synchronizeRootNodeWithParentPage({ node, parentObjectId, parentObjectType, pageElement, lockPage, cleanSync, flatten, }) {
+        if (cleanSync) {
+            this.logger.info('Clean sync enabled - removing existing content');
+            try {
+                await this.destinationRepository.deleteChildBlocks({
+                    parentPageId: parentObjectId,
+                });
+                this.logger.info('Successfully removed existing content');
             }
-            const updatedPage = await this.destinationRepository.updatePage({
-                pageId: parentObjectId,
+            catch (error) {
+                this.logger.warn('Failed to remove existing content, continuing with sync', { error });
+            }
+        }
+        if (flatten) {
+            const newPage = await this.destinationRepository.createPage({
                 pageElement,
+                parentObjectId,
+                parentObjectType,
             });
-            pageElement.id = updatedPage.pageId;
-            this.logger.info(`Updated parent page ${parentObjectId}`);
-            await this.lockPageIfNeeded(parentObjectId, lockPage);
+            pageElement.id = newPage.pageId;
             return { page: pageElement, treeNodeId: node.id };
         }
+        const updatedPage = await this.destinationRepository.updatePage({
+            pageId: parentObjectId,
+            pageElement,
+        });
+        pageElement.id = updatedPage.pageId;
+        this.logger.info(`Updated parent page ${parentObjectId}`);
+        await this.lockPageIfNeeded(parentObjectId, lockPage);
+        return { page: pageElement, treeNodeId: node.id };
+    }
+    async synchronizeRootNodeWithParentDatabase({ node, parentObjectId, parentObjectType, pageElement, cleanSync, }) {
+        // If clean sync is enabled, delete all existing content first
         if (cleanSync) {
             await this.destinationRepository.deleteChildBlocks({
                 parentPageId: parentObjectId,
@@ -76725,7 +76797,7 @@ class SynchronizeMarkdownToNotion {
             treeNodeId: childNode.id,
         });
         // Recursively process children
-        for (const grandChild of childNode.children) {
+        await Promise.all(childNode.children.map(async (grandChild) => {
             const grandChildSyncResult = await this.synchronizeChildNode({
                 childNode: grandChild,
                 parentPageId: pageElement.id,
@@ -76733,7 +76805,7 @@ class SynchronizeMarkdownToNotion {
                 forceNew,
             });
             syncResult.push(...grandChildSyncResult);
-        }
+        }));
         await this.lockPageIfNeeded(pageElement.id, lockPage);
         return syncResult;
     }


### PR DESCRIPTION
Related to #70 

## Description

This PR adds a new `--flat` option that allows users to flatten the page tree structure when synchronizing markdown files to Notion. When enabled, all pages become direct children of the destination instead of maintaining nested folder structures, making it particularly useful for database syncs where you want all items at the same level.

## Changes

### Core Features

- **Added `flatten()` method to `TreeNode`**: Recursively flattens all children, excluding the root node itself
- **Added `flatten()` method to `SiteMap`**: Returns a new SiteMap instance with the tree flattened under the root node, including a root copy as the first child
- **Updated `SynchronizeMarkdownToNotion` feature**:
  - Added `flatten` option to `SynchronizeOptions` interface
  - When `flatten` is true, the root node is skipped during synchronization
  - All flattened pages are created as direct children of the parent page/database
  - Refactored root node synchronization logic to handle both page and database destinations separately
- **Updated `PreviewSynchronization` feature**: Added `flatten` option to preview how the structure will look when flattened

### CLI Commands

- **`sync` command**: Added `--flat` flag to flatten the result page tree
- **`preview-sync` command**: Added `--flat` flag to preview flattened structure

### GitHub Actions

- **Sync action**: Added `flat` input parameter to support flattening in CI/CD workflows

### Documentation

- Updated CLI commands documentation with examples and use cases for the `--flat` option
- Updated database sync guide with flat structure section
- Updated GitHub Actions documentation with flat sync examples
- Added callouts explaining when and why to use flat mode

### Tests

- Added comprehensive unit tests for `TreeNode.flatten()` method
- Added comprehensive unit tests for `SiteMap.flatten()` method
- Added tests for `PreviewSynchronization` with flatten option
- Added tests for `MkNotes` class with flatten option
- Updated existing tests to account for the new `flatten` parameter

## Use Cases

The `--flat` option is particularly useful for:

1. **Database syncs**: When syncing to Notion databases, flat structure ensures all documents appear at the same level, making them easier to filter, sort, and manage with database views
2. **Simple document lists**: Creating a flat list of documents without nested folder structures
3. **Simplified navigation**: When folder hierarchy isn't important and you want all pages visible at once

## Example

**Without `--flat`:**

```
Parent Page
  └── docs/
      ├── getting-started.md
      └── guides/
          └── installation.md
```

**With `--flat`:**

```
Parent Page
  ├── docs/ (root copy)
  ├── getting-started.md
  └── installation.md
```

## Testing

- [x] All existing tests pass
- [x] New tests added for flatten functionality
- [x] Tests cover edge cases (empty trees, nested structures, root node handling)
- [x] Manual testing performed for both CLI and GitHub Actions

## Checklist

All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
