### PR TITLE
Fix/flat database option

### DIFF
--- a/preview/index.js
+++ b/preview/index.js
@@ -76596,7 +76596,8 @@ class SynchronizeMarkdownToNotion {
             try {
                 const childResults = await this.synchronizeChildNode({
                     childNode,
-                    parentPageId: rootPageElement?.id ?? parentObjectId,
+                    parentObjectId: rootPageElement?.id ?? parentObjectId,
+                    parentObjectType: rootPageElement ? 'page' : parentObjectType,
                     lockPage,
                     forceNew,
                 });
@@ -76712,7 +76713,7 @@ class SynchronizeMarkdownToNotion {
     /**
      * Synchronizes a child node and its descendants recursively
      */
-    async synchronizeChildNode({ childNode, parentPageId, lockPage, forceNew, }) {
+    async synchronizeChildNode({ childNode, parentObjectId, parentObjectType, lockPage, forceNew, }) {
         const syncResult = [];
         const filePath = childNode.filepath;
         this.logger.info(`Processing file: ${filePath}`);
@@ -76734,8 +76735,8 @@ class SynchronizeMarkdownToNotion {
             }
             const newPage = await this.destinationRepository.createPage({
                 pageElement,
-                parentObjectId: parentPageId,
-                parentObjectType: 'page',
+                parentObjectId,
+                parentObjectType,
             });
             this.logger.info(`Created Notion page for file: ${filePath}`);
             if (!newPage.pageId) {
@@ -76751,7 +76752,8 @@ class SynchronizeMarkdownToNotion {
         await Promise.all(childNode.children.map(async (grandChild) => {
             const grandChildSyncResult = await this.synchronizeChildNode({
                 childNode: grandChild,
-                parentPageId: pageElement.id,
+                parentObjectId: pageElement.id,
+                parentObjectType: 'page',
                 lockPage,
                 forceNew,
             });

--- a/src/domains/synchronization/features/synchronize-markdown-to-notion.feature.ts
+++ b/src/domains/synchronization/features/synchronize-markdown-to-notion.feature.ts
@@ -248,7 +248,8 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
       try {
         const childResults = await this.synchronizeChildNode({
           childNode,
-          parentPageId: rootPageElement?.id ?? parentObjectId,
+          parentObjectId: rootPageElement?.id ?? parentObjectId,
+          parentObjectType: rootPageElement ? 'page' : parentObjectType,
           lockPage,
           forceNew,
         });
@@ -435,12 +436,14 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
    */
   private async synchronizeChildNode({
     childNode,
-    parentPageId,
+    parentObjectId,
+    parentObjectType,
     lockPage,
     forceNew,
   }: {
     childNode: TreeNode;
-    parentPageId: string;
+    parentObjectId: string;
+    parentObjectType: ObjectType;
     lockPage: boolean;
     forceNew: boolean;
   }): Promise<SynchronizationResult[]> {
@@ -468,8 +471,8 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
 
       const newPage = await this.destinationRepository.createPage({
         pageElement,
-        parentObjectId: parentPageId,
-        parentObjectType: 'page',
+        parentObjectId,
+        parentObjectType,
       });
 
       this.logger.info(`Created Notion page for file: ${filePath}`);
@@ -491,7 +494,8 @@ export class SynchronizeMarkdownToNotion<T, U extends Page> {
       childNode.children.map(async (grandChild) => {
         const grandChildSyncResult = await this.synchronizeChildNode({
           childNode: grandChild,
-          parentPageId: pageElement.id!,
+          parentObjectId: pageElement.id!,
+          parentObjectType: 'page',
           lockPage,
           forceNew,
         });

--- a/sync/index.js
+++ b/sync/index.js
@@ -76645,7 +76645,8 @@ class SynchronizeMarkdownToNotion {
             try {
                 const childResults = await this.synchronizeChildNode({
                     childNode,
-                    parentPageId: rootPageElement?.id ?? parentObjectId,
+                    parentObjectId: rootPageElement?.id ?? parentObjectId,
+                    parentObjectType: rootPageElement ? 'page' : parentObjectType,
                     lockPage,
                     forceNew,
                 });
@@ -76761,7 +76762,7 @@ class SynchronizeMarkdownToNotion {
     /**
      * Synchronizes a child node and its descendants recursively
      */
-    async synchronizeChildNode({ childNode, parentPageId, lockPage, forceNew, }) {
+    async synchronizeChildNode({ childNode, parentObjectId, parentObjectType, lockPage, forceNew, }) {
         const syncResult = [];
         const filePath = childNode.filepath;
         this.logger.info(`Processing file: ${filePath}`);
@@ -76783,8 +76784,8 @@ class SynchronizeMarkdownToNotion {
             }
             const newPage = await this.destinationRepository.createPage({
                 pageElement,
-                parentObjectId: parentPageId,
-                parentObjectType: 'page',
+                parentObjectId,
+                parentObjectType,
             });
             this.logger.info(`Created Notion page for file: ${filePath}`);
             if (!newPage.pageId) {
@@ -76800,7 +76801,8 @@ class SynchronizeMarkdownToNotion {
         await Promise.all(childNode.children.map(async (grandChild) => {
             const grandChildSyncResult = await this.synchronizeChildNode({
                 childNode: grandChild,
-                parentPageId: pageElement.id,
+                parentObjectId: pageElement.id,
+                parentObjectType: 'page',
                 lockPage,
                 forceNew,
             });


### PR DESCRIPTION
All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally before submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

## Description

This PR fixes a bug in the `--flat` database synchronization feature where child pages were incorrectly assumed to always be created under parent pages, even when the parent object was a database.

## What Changed

- **Modified `synchronizeChildNode` method signature**: Changed from accepting `parentPageId: string` to accepting both `parentObjectId: string` and `parentObjectType: ObjectType`
- **Updated method calls**: All calls to `synchronizeChildNode` now pass the correct parent object type (either `'page'` or `'database'`) instead of hardcoding `'page'`
- **Fixed parent object type propagation**: When creating child pages, the method now correctly identifies whether the parent is a page or database and passes this information through the recursive call chain

## Why This Change Was Needed

When using the `--flat` option with database synchronization, all markdown files become direct children of the database. However, the previous implementation hardcoded `parentObjectType: 'page'` when creating child pages, which caused issues when:

1. The root object is a database (not a page)
2. Child pages need to be created directly under the database
3. The recursive synchronization needs to maintain the correct parent object type context

This fix ensures that when syncing with `--flat` to a database, child pages are correctly created as database items rather than attempting to create them as sub-pages of a non-existent parent page.

## Technical Details

The key changes are in `synchronize-markdown-to-notion.feature.ts`:

1. **Line 251-252**: Updated the initial call to `synchronizeChildNode` to pass `parentObjectType` based on whether `rootPageElement` exists (indicating a page parent) or not (indicating a database parent)

2. **Lines 437-448**: Updated the `synchronizeChildNode` method signature to accept `parentObjectId` and `parentObjectType` instead of just `parentPageId`

3. **Lines 472-476**: Updated the `createPage` call to use the passed `parentObjectType` instead of hardcoding `'page'`

4. **Lines 495-498**: Updated recursive calls to maintain the correct parent type (always `'page'` for grandchildren since they're created under pages, not databases)

## Testing

- [ ] Manual testing with `--flat` option on database destination
- [ ] Manual testing with `--flat` option on page destination
- [ ] Manual testing without `--flat` option (existing behavior should remain unchanged)
- [ ] Verify that nested pages are created correctly in both scenarios
