### PR TITLE
ci(action-scripts): add action scripts build check in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,3 +22,31 @@ jobs:
 
       - name: Run tests
         run: yarn test
+
+  check-action-scripts-build:
+    name: Check action scripts build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build action scripts
+        run: yarn build:actions
+
+      # Check if the files are in sync with the main code
+      - name: Check if the files are in sync with the main code
+        run: |
+          if ! git diff --exit-code; then
+            echo "The files are not in sync with the main code"
+            git diff
+            exit 1
+          fi


### PR DESCRIPTION
# Add CI check for action scripts build

## Description

This PR adds a new CI job to the tests workflow that ensures GitHub Action scripts are properly built and in sync with the source code.

## Changes

- Added `check-action-scripts-build` job to `.github/workflows/tests.yaml`
- The job builds action scripts using `yarn build:actions` and verifies they are in sync with the repository state
- This prevents issues where action scripts might be out of sync with the source code

## Why

While the action scripts are built locally via the pre-commit hook, this CI check ensures:

1. Action scripts are always built correctly in the CI environment
2. Any uncommitted build artifacts are detected before merging
3. Consistency between local and CI environments

## Testing

- [x] Does your submission pass tests?
- [x] Have you lint your code locally before submission?
- [x] Have you successfully run tests with your changes locally?

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
